### PR TITLE
feat(kaos): add SSH backend and harden path/io semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array 0.14.7",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20,12 +30,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -114,6 +139,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -243,10 +281,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bcrypt-pbkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aeac2e1fe888769f34f05ac343bbef98b14d1ffb292ab69d4608b3abc86f2a2"
+dependencies = [
+ "blowfish",
+ "pbkdf2",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "bit-set"
@@ -268,6 +335,18 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -275,7 +354,35 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "blowfish"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -303,6 +410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -354,6 +476,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -373,7 +506,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -427,6 +560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +585,38 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -479,6 +650,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-models"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0940496e5c83c54f3b753d5317daec82e8edac71c33aaa1f666d76f518de2444"
+dependencies = [
+ "hax-lib",
+ "pastey 0.1.1",
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -535,13 +717,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array 0.14.7",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37387ceb32048ff590f2cbd24d8b05fffe63c3f69a5cfa089d4f722ca4385a19"
+dependencies = [
+ "ctutils",
+ "num-traits",
+ "rand_core 0.10.0-rc-3",
+ "serdect",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "crypto-primes"
+version = "0.7.0-pre.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79c98a281f9441200b24e3151407a629bfbe720399186e50516da939195e482"
+dependencies = [
+ "crypto-bigint 0.7.0-rc.18",
+ "libm",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -563,6 +790,51 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -632,6 +904,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,9 +972,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bf3682cdec91817be507e4aa104314898b95b84d74f3d43882210101a545b6"
+dependencies = [
+ "block-buffer 0.11.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.0",
 ]
 
 [[package]]
@@ -732,10 +1049,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ego-tree"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff",
+ "generic-array 0.14.7",
+ "group",
+ "hkdf",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "email_address"
@@ -753,6 +1130,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum_dispatch"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -818,6 +1207,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +1259,18 @@ dependencies = [
  "borrow-or-share",
  "ref-cast",
  "serde",
+]
+
+[[package]]
+name = "flurry"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5efcf77a4da27927d3ab0509dec5b0954bb3bc59da5a1de9e52642ebd4cdf9"
+dependencies = [
+ "ahash",
+ "num_cpus",
+ "parking_lot",
+ "seize",
 ]
 
 [[package]]
@@ -1000,6 +1417,18 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+dependencies = [
+ "generic-array 0.14.7",
+ "rustversion",
+ "typenum",
 ]
 
 [[package]]
@@ -1039,6 +1468,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,6 +1492,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1096,6 +1546,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "hax-lib"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d9ba66d1739c68e0219b2b2238b5c4145f491ebf181b9c6ab561a19352ae86"
+dependencies = [
+ "hax-lib-macros",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "hax-lib-macros"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24ba777a231a58d1bce1d68313fa6b6afcc7966adef23d60f45b8a2b9b688bf1"
+dependencies = [
+ "hax-lib-macros-types",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "hax-lib-macros-types"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "867e19177d7425140b417cd27c2e05320e727ee682e98368f88b7194e80ad515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,12 +1595,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1198,6 +1715,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b229d73f5803b562cc26e4da0396c8610a4ee209f4fac8fa4f8d709166dc45"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1442,7 +1968,39 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array",
+ "block-padding",
+ "generic-array 0.14.7",
+]
+
+[[package]]
+name = "internal-russh-forked-ssh-key"
+version = "0.6.16+upstream-0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe44f2bbd99fcb302e246e2d6bcf51aeda346d02a365f80296a07a8c711b6da6"
+dependencies = [
+ "argon2",
+ "bcrypt-pbkdf",
+ "digest 0.11.0",
+ "ecdsa",
+ "ed25519-dalek",
+ "hex",
+ "hmac",
+ "num-bigint-dig",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha1 0.10.6",
+ "sha1 0.11.0-rc.5",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "signature 3.0.0-rc.6",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1566,8 +2124,12 @@ dependencies = [
  "dirs",
  "futures",
  "glob",
+ "russh",
+ "russh-sftp",
  "serde",
+ "sha2 0.10.9",
  "tokio",
+ "typed-path",
 ]
 
 [[package]]
@@ -1589,7 +2151,7 @@ dependencies = [
  "jsonschema",
  "kaos",
  "kosong",
- "md5",
+ "md5 0.8.0",
  "rand 0.9.2",
  "regex",
  "reqwest 0.12.28",
@@ -1642,6 +2204,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libbz2-rs-sys"
@@ -1654,6 +2219,78 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libcrux-intrinsics"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9ee7ef66569dd7516454fe26de4e401c0c62073929803486b96744594b9632"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-ml-kem"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6a88086bf11bd2ec90926c749c4a427f2e59841437dbdede8cde8a96334ab"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-secrets",
+ "libcrux-sha3",
+ "libcrux-traits",
+ "rand 0.9.2",
+ "tls_codec",
+]
+
+[[package]]
+name = "libcrux-platform"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db82d058aa76ea315a3b2092f69dfbd67ddb0e462038a206e1dcd73f058c0778"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "libcrux-secrets"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4dbbf6bc9f2bc0f20dc3bea3e5c99adff3bdccf6d2a40488963da69e2ec307"
+dependencies = [
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-sha3"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2400bec764d1c75b8a496d5747cffe32f1fb864a12577f0aca2f55a92021c962"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics",
+ "libcrux-platform",
+ "libcrux-traits",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adfd58e79d860f6b9e40e35127bfae9e5bd3ade33201d1347459011a2add034"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.9.2",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1706,7 +2343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 dependencies = [
  "crc",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1757,6 +2394,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "md5"
@@ -1831,6 +2474,18 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -1881,6 +2536,23 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -1969,7 +2641,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -2031,6 +2703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2725,63 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct 0.2.0",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pageant"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b537f975f6d8dcf48db368d7ec209d583b015713b5df0f5d92d2631e4ff5595"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "delegate",
+ "futures",
+ "log",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "windows",
+ "windows-strings",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2072,6 +2807,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2083,8 +2835,26 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2197,6 +2967,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der 0.7.10",
+ "pbkdf2",
+ "scrypt",
+ "sha2 0.10.9",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0-rc.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+dependencies = [
+ "der 0.8.0",
+ "spki 0.8.0-rc.4",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +3030,29 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -2252,6 +3092,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2268,7 +3139,7 @@ checksum = "fd1395947e69c07400ef4d43db0051d6f773c21f647ad8b97382fc01f0204c60"
 dependencies = [
  "futures",
  "indexmap",
- "nix",
+ "nix 0.30.1",
  "tokio",
  "tracing",
  "windows",
@@ -2418,6 +3289,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0-rc-3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f66ee92bc15280519ef199a274fe0cafff4245d31bc39aaa31c011ad56cb1f05"
 
 [[package]]
 name = "redox_syscall"
@@ -2597,6 +3474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,7 +3493,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2626,7 +3513,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "oauth2",
- "pastey",
+ "pastey 0.2.1",
  "pin-project-lite",
  "process-wrap",
  "rand 0.9.2",
@@ -2657,6 +3544,129 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rsa"
+version = "0.10.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a2b1eacbc34fbaf77f6f1db1385518446008d49b9f9f59dc9d1340fce4ca9e"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-bigint 0.7.0-rc.18",
+ "crypto-primes",
+ "digest 0.11.0",
+ "pkcs1",
+ "pkcs8 0.11.0-rc.11",
+ "rand_core 0.10.0-rc-3",
+ "sha2 0.11.0-rc.5",
+ "signature 3.0.0-rc.6",
+ "spki 0.8.0-rc.4",
+ "zeroize",
+]
+
+[[package]]
+name = "russh"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fe22d10a0e39c1134a971d5b8db8a40357b48ef22d81fa8d6eac22202dd782"
+dependencies = [
+ "aes",
+ "aws-lc-rs",
+ "bitflags",
+ "block-padding",
+ "byteorder",
+ "bytes",
+ "cbc",
+ "ctr",
+ "curve25519-dalek",
+ "data-encoding",
+ "delegate",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "enum_dispatch",
+ "flate2",
+ "futures",
+ "generic-array 1.3.5",
+ "getrandom 0.2.17",
+ "hex-literal",
+ "hmac",
+ "home",
+ "inout",
+ "internal-russh-forked-ssh-key",
+ "libcrux-ml-kem",
+ "log",
+ "md5 0.7.0",
+ "num-bigint",
+ "p256",
+ "p384",
+ "p521",
+ "pageant",
+ "pbkdf2",
+ "pkcs1",
+ "pkcs5",
+ "pkcs8 0.10.2",
+ "rand 0.9.2",
+ "rand_core 0.10.0-rc-3",
+ "rsa",
+ "russh-cryptovec",
+ "russh-util",
+ "sec1",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "ssh-encoding",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "russh-cryptovec"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb0ed583ff0f6b4aa44c7867dd7108df01b30571ee9423e250b4cc939f8c6cf"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.29.0",
+ "ssh-encoding",
+ "winapi",
+]
+
+[[package]]
+name = "russh-sftp"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bb94393cafad0530145b8f626d8687f1ee1dedb93d7ba7740d6ae81868b13b5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "flurry",
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "russh-util"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668424a5dde0bcb45b55ba7de8476b93831b4aa2fa6947e145f3b053e22c60b6"
+dependencies = [
+ "chrono",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2760,7 +3770,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2774,6 +3784,15 @@ name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -2841,6 +3860,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct 0.2.0",
+ "der 0.7.10",
+ "generic-array 0.14.7",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,6 +3906,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "seize"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689224d06523904ebcc9b482c6a3f4f7fb396096645c4cd10c0d2ff7371a34d3"
 
 [[package]]
 name = "selectors"
@@ -2989,6 +4039,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9af4a3e75ebd5599b30d4de5768e00b5095d518a79fefc3ecbaf77e665d1ec06"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,7 +4065,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0",
 ]
 
 [[package]]
@@ -3016,7 +4087,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0",
 ]
 
 [[package]]
@@ -3042,6 +4124,26 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a96996ccff7dfa16f052bd995b4cecc72af22c35138738dc029f0ead6608d"
+dependencies = [
+ "digest 0.11.0",
+ "rand_core 0.10.0-rc-3",
 ]
 
 [[package]]
@@ -3085,6 +4187,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+dependencies = [
+ "base64ct",
+ "der 0.8.0",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +4223,35 @@ dependencies = [
  "http-body",
  "http-body-util",
  "pin-project-lite",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "cbc",
+ "chacha20",
+ "cipher",
+ "ctr",
+ "poly1305",
+ "ssh-encoding",
+ "subtle",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "bytes",
+ "pem-rfc7468 0.7.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3361,6 +4518,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +4550,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tokio"
@@ -3609,9 +4796,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-path"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43ffa54726cdc9ea78392023ffe9fe9cf9ac779e1c6fcb0d23f9862e3879d20"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
@@ -3644,10 +4831,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -4468,7 +5671,7 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "generic-array",
+ "generic-array 0.14.7",
  "getrandom 0.3.4",
  "hmac",
  "indexmap",
@@ -4476,7 +5679,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "ppmd-rust",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "typed-path",
  "zeroize",

--- a/kaos/Cargo.toml
+++ b/kaos/Cargo.toml
@@ -12,6 +12,10 @@ futures.workspace = true
 async-trait.workspace = true
 dirs.workspace = true
 glob.workspace = true
+typed-path = "0.12"
+russh = "0.57"
+russh-sftp = "2.1"
+sha2 = "0.10"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/kaos/src/lib.rs
+++ b/kaos/src/lib.rs
@@ -51,6 +51,29 @@ pub trait AsyncWritable: Send + Sync {
     async fn close(&mut self) -> Result<()>;
 }
 
+/// Summary of output dropped by a process transport layer under backpressure.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ProcessOutputOverflow {
+    pub stdout_dropped_chunks: u64,
+    pub stdout_dropped_bytes: u64,
+    pub stderr_dropped_chunks: u64,
+    pub stderr_dropped_bytes: u64,
+}
+
+impl ProcessOutputOverflow {
+    pub fn total_dropped_chunks(self) -> u64 {
+        self.stdout_dropped_chunks + self.stderr_dropped_chunks
+    }
+
+    pub fn total_dropped_bytes(self) -> u64 {
+        self.stdout_dropped_bytes + self.stderr_dropped_bytes
+    }
+
+    pub fn has_drops(self) -> bool {
+        self.total_dropped_chunks() > 0
+    }
+}
+
 /// Process handle returned by Kaos exec.
 #[async_trait::async_trait]
 pub trait KaosProcess: Send + Sync {
@@ -65,6 +88,9 @@ pub trait KaosProcess: Send + Sync {
         None
     }
     fn take_stderr(&mut self) -> Option<Box<dyn AsyncReadable>> {
+        None
+    }
+    fn output_overflow_summary(&self) -> Option<ProcessOutputOverflow> {
         None
     }
 }

--- a/kaos/src/lib.rs
+++ b/kaos/src/lib.rs
@@ -2,17 +2,19 @@
 
 pub mod local;
 pub mod path;
+pub mod ssh;
 
 mod current;
+mod line_stream;
 
 pub use current::{
     CurrentKaosToken, get_current_kaos, reset_current_kaos, set_current_kaos,
     with_current_kaos_scope,
 };
 pub use local::LocalKaos;
-pub use path::KaosPath;
+pub use path::{KaosPath, KaosPathStyle};
+pub use ssh::{SshHostKeyPolicy, SshKaos, SshKaosOptions};
 
-use std::path::PathBuf;
 use std::pin::Pin;
 
 use anyhow::Result;
@@ -71,7 +73,19 @@ pub trait KaosProcess: Send + Sync {
 #[async_trait::async_trait]
 pub trait Kaos: Send + Sync {
     fn name(&self) -> &str;
+    fn storage_name(&self) -> String {
+        self.name().to_string()
+    }
+
     fn platform(&self) -> KaosPlatform;
+
+    fn path_style(&self) -> KaosPathStyle {
+        match self.platform().os.as_str() {
+            "windows" => KaosPathStyle::Windows,
+            _ => KaosPathStyle::Posix,
+        }
+    }
+
     fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath;
     fn home(&self) -> KaosPath;
     fn cwd(&self) -> KaosPath;
@@ -115,7 +129,7 @@ pub type LineStream = Pin<Box<dyn Stream<Item = Result<String>> + Send>>;
 /// Helper to map string/KaosPath to KaosPath.
 pub fn normalize_path_arg(arg: &StrOrKaosPath<'_>) -> KaosPath {
     match arg {
-        StrOrKaosPath::Str(s) => KaosPath::from(PathBuf::from(s)),
+        StrOrKaosPath::Str(s) => KaosPath::from_style(get_current_kaos().path_style(), *s),
         StrOrKaosPath::KaosPath(p) => (*p).clone(),
     }
 }

--- a/kaos/src/line_stream.rs
+++ b/kaos/src/line_stream.rs
@@ -1,0 +1,56 @@
+use std::collections::VecDeque;
+
+use futures::stream;
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+
+use crate::LineStream;
+
+pub(crate) fn line_stream_from_async_read<R>(reader: R) -> LineStream
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    struct LineStreamState<R>
+    where
+        R: AsyncRead + Unpin + Send,
+    {
+        reader: BufReader<R>,
+        buf: Vec<u8>,
+        pending: VecDeque<String>,
+        done: bool,
+    }
+
+    let state = LineStreamState {
+        reader: BufReader::new(reader),
+        buf: Vec::new(),
+        pending: VecDeque::new(),
+        done: false,
+    };
+
+    let stream = stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(line) = state.pending.pop_front() {
+                return Some((Ok(line), state));
+            }
+            if state.done {
+                return None;
+            }
+
+            state.buf.clear();
+            match state.reader.read_until(b'\n', &mut state.buf).await {
+                Ok(0) => {
+                    state.done = true;
+                }
+                Ok(_) => {
+                    let text = String::from_utf8_lossy(&state.buf);
+                    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+                    for line in normalized.split_inclusive('\n').map(str::to_string) {
+                        state.pending.push_back(line);
+                    }
+                }
+                Err(err) => return Some((Err(err.into()), state)),
+            }
+        }
+    });
+
+    Box::pin(stream)
+}

--- a/kaos/src/local.rs
+++ b/kaos/src/local.rs
@@ -1,15 +1,13 @@
-use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
-use futures::stream;
 use tokio::fs;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
 use crate::{
     AsyncReadable, AsyncWritable, Kaos, KaosPath, KaosPlatform, KaosProcess, LineStream,
-    StatResult, StrOrKaosPath,
+    StatResult, StrOrKaosPath, line_stream::line_stream_from_async_read,
 };
 
 #[cfg(unix)]
@@ -202,10 +200,14 @@ impl Kaos for LocalKaos {
         }
     }
 
+    fn path_style(&self) -> crate::KaosPathStyle {
+        crate::KaosPathStyle::local_default()
+    }
+
     fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath {
         let path = match path {
             StrOrKaosPath::Str(s) => PathBuf::from(s),
-            StrOrKaosPath::KaosPath(p) => p.as_path().to_path_buf(),
+            StrOrKaosPath::KaosPath(p) => p.unsafe_to_local_path(),
         };
         KaosPath::from(normalize_path(&path))
     }
@@ -219,15 +221,16 @@ impl Kaos for LocalKaos {
     }
 
     async fn chdir(&self, path: &KaosPath) -> Result<()> {
-        std::env::set_current_dir(path.as_path())?;
+        std::env::set_current_dir(path.unsafe_to_local_path())?;
         Ok(())
     }
 
     async fn stat(&self, path: &KaosPath, follow_symlinks: bool) -> Result<StatResult> {
+        let local_path = path.unsafe_to_local_path();
         let metadata = if follow_symlinks {
-            fs::metadata(path.as_path()).await?
+            fs::metadata(&local_path).await?
         } else {
-            fs::symlink_metadata(path.as_path()).await?
+            fs::symlink_metadata(&local_path).await?
         };
 
         let st_size = metadata.len();
@@ -298,8 +301,9 @@ impl Kaos for LocalKaos {
     }
 
     async fn iterdir(&self, path: &KaosPath) -> Result<Vec<KaosPath>> {
+        let local_path = path.unsafe_to_local_path();
         let mut entries = Vec::new();
-        let mut dir = fs::read_dir(path.as_path()).await?;
+        let mut dir = fs::read_dir(&local_path).await?;
         while let Some(entry) = dir.next_entry().await? {
             entries.push(KaosPath::from(entry.path()));
         }
@@ -312,7 +316,11 @@ impl Kaos for LocalKaos {
         pattern: &str,
         case_sensitive: bool,
     ) -> Result<Vec<KaosPath>> {
-        let search = path.as_path().join(pattern).to_string_lossy().to_string();
+        let search = path
+            .unsafe_to_local_path()
+            .join(pattern)
+            .to_string_lossy()
+            .to_string();
         let options = glob::MatchOptions {
             case_sensitive,
             require_literal_separator: true,
@@ -328,7 +336,7 @@ impl Kaos for LocalKaos {
     }
 
     async fn read_bytes(&self, path: &KaosPath, limit: Option<usize>) -> Result<Vec<u8>> {
-        let mut data = fs::read(path.as_path()).await?;
+        let mut data = fs::read(path.unsafe_to_local_path()).await?;
         if let Some(n) = limit {
             data.truncate(n);
         }
@@ -336,11 +344,11 @@ impl Kaos for LocalKaos {
     }
 
     async fn read_text(&self, path: &KaosPath) -> Result<String> {
-        Ok(fs::read_to_string(path.as_path()).await?)
+        Ok(fs::read_to_string(path.unsafe_to_local_path()).await?)
     }
 
     async fn read_lines(&self, path: &KaosPath) -> Result<Vec<String>> {
-        let text = fs::read_to_string(path.as_path()).await?;
+        let text = fs::read_to_string(path.unsafe_to_local_path()).await?;
         let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
         Ok(normalized
             .split_inclusive('\n')
@@ -349,107 +357,60 @@ impl Kaos for LocalKaos {
     }
 
     async fn read_lines_stream(&self, path: &KaosPath) -> Result<LineStream> {
-        struct LineStreamState<R>
-        where
-            R: AsyncRead + Unpin + Send,
-        {
-            reader: BufReader<R>,
-            buf: Vec<u8>,
-            pending: VecDeque<String>,
-            done: bool,
-        }
-
-        let file = fs::File::open(path.as_path()).await?;
-        let state = LineStreamState {
-            reader: BufReader::new(file),
-            buf: Vec::new(),
-            pending: VecDeque::new(),
-            done: false,
-        };
-
-        let stream = stream::unfold(state, |mut state| async move {
-            loop {
-                if let Some(line) = state.pending.pop_front() {
-                    return Some((Ok(line), state));
-                }
-                if state.done {
-                    return None;
-                }
-
-                state.buf.clear();
-                match state.reader.read_until(b'\n', &mut state.buf).await {
-                    Ok(0) => {
-                        state.done = true;
-                    }
-                    Ok(_) => {
-                        let text = String::from_utf8_lossy(&state.buf);
-                        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
-                        let lines: Vec<String> = normalized
-                            .split_inclusive('\n')
-                            .map(str::to_string)
-                            .collect();
-                        if lines.is_empty() {
-                            continue;
-                        }
-                        for line in lines {
-                            state.pending.push_back(line);
-                        }
-                    }
-                    Err(err) => return Some((Err(err.into()), state)),
-                }
-            }
-        });
-
-        Ok(Box::pin(stream))
+        let file = fs::File::open(path.unsafe_to_local_path()).await?;
+        Ok(line_stream_from_async_read(file))
     }
 
     async fn write_bytes(&self, path: &KaosPath, data: &[u8]) -> Result<usize> {
-        fs::write(path.as_path(), data).await?;
+        fs::write(path.unsafe_to_local_path(), data).await?;
         Ok(data.len())
     }
 
     async fn write_text(&self, path: &KaosPath, data: &str, append: bool) -> Result<usize> {
+        let local_path = path.unsafe_to_local_path();
         if append {
             let mut file = fs::OpenOptions::new()
                 .create(true)
                 .append(true)
-                .open(path.as_path())
+                .open(&local_path)
                 .await?;
             file.write_all(data.as_bytes()).await?;
         } else {
-            fs::write(path.as_path(), data).await?;
+            fs::write(&local_path, data).await?;
         }
         Ok(data.len())
     }
 
     async fn chmod(&self, path: &KaosPath, mode: u32) -> Result<()> {
+        let local_path = path.unsafe_to_local_path();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             let permissions = std::fs::Permissions::from_mode(mode);
-            fs::set_permissions(path.as_path(), permissions).await?;
+            fs::set_permissions(&local_path, permissions).await?;
         }
 
         #[cfg(not(unix))]
         {
             // Non-Unix platforms do not expose POSIX permission bits; map write bits to readonly.
-            let mut perms = fs::metadata(path.as_path()).await?.permissions();
+            let mut perms = fs::metadata(&local_path).await?.permissions();
             let readonly = (mode & 0o222) == 0;
             perms.set_readonly(readonly);
-            fs::set_permissions(path.as_path(), perms).await?;
+            fs::set_permissions(&local_path, perms).await?;
         }
 
         Ok(())
     }
 
     async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> Result<()> {
+        let local_path = path.unsafe_to_local_path();
         if parents {
-            if let Err(err) = fs::create_dir_all(path.as_path()).await
+            if let Err(err) = fs::create_dir_all(&local_path).await
                 && !exist_ok
             {
                 return Err(err.into());
             }
-        } else if let Err(err) = fs::create_dir(path.as_path()).await
+        } else if let Err(err) = fs::create_dir(&local_path).await
             && !exist_ok
         {
             return Err(err.into());

--- a/kaos/src/path.rs
+++ b/kaos/src/path.rs
@@ -1,62 +1,135 @@
-use std::ffi::OsStr;
 use std::fmt;
-use std::path::{Component, Path, PathBuf};
+use std::hash::{Hash, Hasher};
+#[cfg(unix)]
+use std::os::unix::ffi::{OsStrExt, OsStringExt};
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
+use typed_path::{PathType, Utf8TypedPath, Utf8TypedPathBuf};
 
 use crate::{
     LineStream, StatResult, StrOrKaosPath, get_current_kaos, normalize_path_arg, normpath,
 };
 
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KaosPathStyle {
+    Posix,
+    Windows,
+}
+
+impl KaosPathStyle {
+    pub fn local_default() -> Self {
+        if cfg!(windows) {
+            Self::Windows
+        } else {
+            Self::Posix
+        }
+    }
+
+    fn path_type(self) -> PathType {
+        match self {
+            Self::Posix => PathType::Unix,
+            Self::Windows => PathType::Windows,
+        }
+    }
+
+    fn separator(self) -> &'static str {
+        match self {
+            Self::Posix => "/",
+            Self::Windows => "\\",
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct KaosPath {
-    path: PathBuf,
+    style: KaosPathStyle,
+    raw: String,
+    local_bytes: Option<Vec<u8>>,
 }
 
 impl KaosPath {
-    pub fn new<P: Into<PathBuf>>(path: P) -> Self {
-        Self { path: path.into() }
+    pub fn new(path: impl AsRef<str>) -> Self {
+        Self {
+            style: get_current_kaos().path_style(),
+            raw: path.as_ref().to_string(),
+            local_bytes: None,
+        }
+    }
+
+    pub fn from_style(style: KaosPathStyle, path: impl AsRef<str>) -> Self {
+        Self {
+            style,
+            raw: path.as_ref().to_string(),
+            local_bytes: None,
+        }
     }
 
     pub fn from(path: PathBuf) -> Self {
-        Self { path }
+        Self::from_local_pathbuf(path)
+    }
+
+    pub fn from_local_pathbuf(path: PathBuf) -> Self {
+        #[cfg(unix)]
+        {
+            let bytes = path.as_os_str().as_bytes().to_vec();
+            Self {
+                style: KaosPathStyle::local_default(),
+                raw: path.to_string_lossy().to_string(),
+                local_bytes: Some(bytes),
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            Self {
+                style: KaosPathStyle::local_default(),
+                raw: path.to_string_lossy().to_string(),
+                local_bytes: None,
+            }
+        }
+    }
+
+    pub fn style(&self) -> KaosPathStyle {
+        self.style
     }
 
     pub fn unsafe_from_local_path(path: &Path) -> Self {
-        Self::from(path.to_path_buf())
+        Self::from_local_pathbuf(path.to_path_buf())
     }
 
     pub fn unsafe_to_local_path(&self) -> PathBuf {
-        self.path.clone()
-    }
-
-    pub fn as_path(&self) -> &Path {
-        &self.path
+        #[cfg(unix)]
+        if let Some(bytes) = &self.local_bytes {
+            return PathBuf::from(std::ffi::OsString::from_vec(bytes.clone()));
+        }
+        PathBuf::from(&self.raw)
     }
 
     pub fn name(&self) -> String {
-        self.path
+        self.as_typed_path()
             .file_name()
-            .map(|s| s.to_string_lossy().to_string())
+            .map(str::to_string)
             .unwrap_or_default()
     }
 
     pub fn parent(&self) -> KaosPath {
-        if let Some(parent) = self.path.parent() {
-            return KaosPath::from(parent.to_path_buf());
+        if let Some(parent) = self.as_typed_path().parent() {
+            return Self::from_style(self.style, parent.as_str());
         }
         if self.is_absolute() {
             return self.clone();
         }
-        KaosPath::from(PathBuf::from("."))
+        Self::from_style(self.style, ".")
     }
 
     pub fn is_absolute(&self) -> bool {
-        self.path.is_absolute()
+        self.as_typed_path().is_absolute()
     }
 
     pub fn joinpath(&self, other: &str) -> Self {
-        Self::from(self.path.join(other))
+        Self::from_typed_path_buf(self.as_typed_path().join(other))
     }
 
     pub fn canonical(&self) -> KaosPath {
@@ -64,17 +137,24 @@ impl KaosPath {
             self.clone()
         } else {
             let cwd = get_current_kaos().cwd();
-            KaosPath::from(cwd.as_path().join(&self.path))
+            cwd.joinpath(&self.raw)
         };
         normpath(&StrOrKaosPath::KaosPath(&abs))
     }
 
     pub fn relative_to(&self, other: &KaosPath) -> Result<KaosPath> {
-        let relative = self
-            .path
-            .strip_prefix(&other.path)
+        if self.style != other.style {
+            return Err(anyhow!(
+                "Cannot compare paths with different styles: {:?} vs {:?}",
+                self.style,
+                other.style
+            ));
+        }
+        let this = self.as_typed_path();
+        let relative = this
+            .strip_prefix(other.as_typed_path().as_str())
             .map_err(|err| anyhow!(err))?;
-        Ok(KaosPath::from(relative.to_path_buf()))
+        Ok(Self::from_style(self.style, relative.as_str()))
     }
 
     pub fn home() -> KaosPath {
@@ -86,17 +166,22 @@ impl KaosPath {
     }
 
     pub fn expanduser(&self) -> KaosPath {
-        let mut components = self.path.components();
-        match components.next() {
-            Some(Component::Normal(part)) if part == OsStr::new("~") => {
-                let mut expanded = KaosPath::home().path;
-                for comp in components {
-                    expanded.push(comp.as_os_str());
-                }
-                KaosPath::from(expanded)
-            }
-            _ => self.clone(),
+        if self.raw == "~" {
+            return KaosPath::home();
         }
+
+        let home = KaosPath::home();
+        let posix_prefix = "~/";
+        let windows_prefix = "~\\";
+
+        if self.raw.starts_with(posix_prefix) {
+            return home.joinpath(&self.raw[posix_prefix.len()..]);
+        }
+        if self.raw.starts_with(windows_prefix) {
+            return home.joinpath(&self.raw[windows_prefix.len()..]);
+        }
+
+        self.clone()
     }
 
     pub async fn stat(&self, follow_symlinks: bool) -> Result<StatResult> {
@@ -166,37 +251,74 @@ impl KaosPath {
     }
 
     pub fn to_string_lossy(&self) -> String {
-        self.path.to_string_lossy().to_string()
+        self.raw.clone()
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn separator(&self) -> &'static str {
+        self.style.separator()
+    }
+
+    fn as_typed_path(&self) -> Utf8TypedPath<'_> {
+        Utf8TypedPath::new(&self.raw, self.style.path_type())
+    }
+
+    fn from_typed_path_buf(path: Utf8TypedPathBuf) -> Self {
+        match path {
+            Utf8TypedPathBuf::Unix(p) => Self::from_style(KaosPathStyle::Posix, p.as_str()),
+            Utf8TypedPathBuf::Windows(p) => Self::from_style(KaosPathStyle::Windows, p.as_str()),
+        }
     }
 }
 
 impl fmt::Debug for KaosPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "KaosPath({:?})", self.path)
+        f.debug_struct("KaosPath")
+            .field("style", &self.style)
+            .field("raw", &self.raw)
+            .finish()
+    }
+}
+
+impl PartialEq for KaosPath {
+    fn eq(&self, other: &Self) -> bool {
+        self.style == other.style && self.raw == other.raw
+    }
+}
+
+impl Eq for KaosPath {}
+
+impl Hash for KaosPath {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.style.hash(state);
+        self.raw.hash(state);
     }
 }
 
 impl fmt::Display for KaosPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.path.to_string_lossy())
+        write!(f, "{}", self.raw)
     }
 }
 
 impl From<&str> for KaosPath {
     fn from(value: &str) -> Self {
-        KaosPath::new(PathBuf::from(value))
+        KaosPath::new(value)
     }
 }
 
 impl From<PathBuf> for KaosPath {
     fn from(value: PathBuf) -> Self {
-        KaosPath::new(value)
+        KaosPath::from_local_pathbuf(value)
     }
 }
 
 impl From<&Path> for KaosPath {
     fn from(value: &Path) -> Self {
-        KaosPath::new(value.to_path_buf())
+        KaosPath::from_local_pathbuf(value.to_path_buf())
     }
 }
 
@@ -217,7 +339,8 @@ impl std::ops::Div<&KaosPath> for KaosPath {
 }
 
 pub fn normalize_path(arg: &crate::StrOrKaosPath<'_>) -> KaosPath {
-    normalize_path_arg(arg)
+    let path = normalize_path_arg(arg);
+    KaosPath::from_typed_path_buf(path.as_typed_path().normalize())
 }
 
 fn mode_is_dir(mode: u32) -> bool {
@@ -226,4 +349,40 @@ fn mode_is_dir(mode: u32) -> bool {
 
 fn mode_is_file(mode: u32) -> bool {
     (mode & 0o170000) == 0o100000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KaosPath, KaosPathStyle};
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::path::PathBuf;
+
+    #[cfg(unix)]
+    #[test]
+    fn from_local_pathbuf_preserves_non_utf8_bytes() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let raw = b"/tmp/kimi-\xFF".to_vec();
+        let path = PathBuf::from(std::ffi::OsString::from_vec(raw.clone()));
+        let kaos_path = KaosPath::from_local_pathbuf(path);
+        let roundtrip = kaos_path.unsafe_to_local_path();
+
+        assert_eq!(roundtrip.as_os_str().as_bytes(), raw.as_slice());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn equality_and_hash_ignore_local_bytes_cache() {
+        let local = KaosPath::from_local_pathbuf(PathBuf::from("/tmp/kimi-path"));
+        let logical = KaosPath::from_style(KaosPathStyle::Posix, "/tmp/kimi-path");
+
+        assert_eq!(local, logical);
+
+        let mut left = DefaultHasher::new();
+        local.hash(&mut left);
+        let mut right = DefaultHasher::new();
+        logical.hash(&mut right);
+        assert_eq!(left.finish(), right.finish());
+    }
 }

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -16,7 +16,7 @@ use russh_sftp::protocol::{OpenFlags, StatusCode};
 use sha2::{Digest, Sha256};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::mpsc::error::TrySendError;
-use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
+use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
 use typed_path::Utf8TypedPathBuf;
 
 use crate::{
@@ -66,6 +66,7 @@ const fn default_connect_timeout_seconds() -> u64 {
 
 const MAX_AGENT_IDENTITIES_TO_TRY: usize = 8;
 const PROCESS_OUTPUT_QUEUE_CAPACITY: usize = 64;
+const DEFAULT_SSH_EXIT_CODE: i32 = 1;
 
 impl SshKaosOptions {
     fn known_hosts_path(&self) -> PathBuf {
@@ -570,8 +571,7 @@ impl Kaos for SshKaos {
 
         let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(PROCESS_OUTPUT_QUEUE_CAPACITY);
         let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(PROCESS_OUTPUT_QUEUE_CAPACITY);
-        let exit_state = Arc::new(ProcessExitState::default());
-        let exit_state_bg = Arc::clone(&exit_state);
+        let (exit_code_tx, exit_code_rx) = watch::channel(None);
 
         tokio::spawn(async move {
             let mut exit_code: Option<i32> = None;
@@ -606,11 +606,7 @@ impl Kaos for SshKaos {
                     _ => {}
                 }
             }
-            *exit_state_bg
-                .code
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(exit_code.unwrap_or(1));
-            exit_state_bg.notify.notify_waiters();
+            let _ = exit_code_tx.send(Some(exit_code.unwrap_or(DEFAULT_SSH_EXIT_CODE)));
         });
 
         Ok(Box::new(SshProcess {
@@ -619,16 +615,10 @@ impl Kaos for SshKaos {
             stderr: Some(QueueReader::new(stderr_rx)),
             null_stdout: QueueReader::empty(),
             null_stderr: QueueReader::empty(),
-            exit_state,
+            exit_code_rx,
             write_half,
         }))
     }
-}
-
-#[derive(Default)]
-struct ProcessExitState {
-    code: Mutex<Option<i32>>,
-    notify: Notify,
 }
 
 struct SshProcess {
@@ -637,7 +627,7 @@ struct SshProcess {
     stderr: Option<QueueReader>,
     null_stdout: QueueReader,
     null_stderr: QueueReader,
-    exit_state: Arc<ProcessExitState>,
+    exit_code_rx: watch::Receiver<Option<i32>>,
     write_half: Arc<AsyncMutex<Option<russh::ChannelWriteHalf<client::Msg>>>>,
 }
 
@@ -648,11 +638,7 @@ impl KaosProcess for SshProcess {
     }
 
     fn returncode(&mut self) -> Option<i32> {
-        *self
-            .exit_state
-            .code
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
+        *self.exit_code_rx.borrow()
     }
 
     async fn wait(&mut self) -> Result<i32> {
@@ -660,7 +646,9 @@ impl KaosProcess for SshProcess {
             if let Some(code) = self.returncode() {
                 return Ok(code);
             }
-            self.exit_state.notify.notified().await;
+            if self.exit_code_rx.changed().await.is_err() {
+                return Ok(self.returncode().unwrap_or(DEFAULT_SSH_EXIT_CODE));
+            }
         }
     }
 

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashSet, VecDeque};
 use std::fmt::Write as _;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -21,7 +22,8 @@ use typed_path::Utf8TypedPathBuf;
 
 use crate::{
     AsyncReadable, AsyncWritable, Kaos, KaosPath, KaosPathStyle, KaosPlatform, KaosProcess,
-    LineStream, StatResult, StrOrKaosPath, line_stream::line_stream_from_async_read,
+    LineStream, ProcessOutputOverflow, StatResult, StrOrKaosPath,
+    line_stream::line_stream_from_async_read,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
@@ -67,6 +69,12 @@ const fn default_connect_timeout_seconds() -> u64 {
 const MAX_AGENT_IDENTITIES_TO_TRY: usize = 8;
 const PROCESS_OUTPUT_QUEUE_CAPACITY: usize = 64;
 const DEFAULT_SSH_EXIT_CODE: i32 = 1;
+
+#[derive(Clone, Copy)]
+enum ProcessStreamKind {
+    Stdout,
+    Stderr,
+}
 
 impl SshKaosOptions {
     fn known_hosts_path(&self) -> PathBuf {
@@ -572,29 +580,40 @@ impl Kaos for SshKaos {
         let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(PROCESS_OUTPUT_QUEUE_CAPACITY);
         let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(PROCESS_OUTPUT_QUEUE_CAPACITY);
         let (exit_code_tx, exit_code_rx) = watch::channel(None);
+        let overflow_state = Arc::new(ProcessOutputOverflowState::default());
+        let overflow_state_bg = Arc::clone(&overflow_state);
 
         tokio::spawn(async move {
             let mut exit_code: Option<i32> = None;
             while let Some(msg) = read_half.wait().await {
                 match msg {
                     ChannelMsg::Data { data } => {
-                        if let Err(err) = stdout_tx.try_send(data.as_ref().to_vec())
-                            && matches!(err, TrySendError::Closed(_))
-                        {
+                        if !forward_process_output_chunk(
+                            &stdout_tx,
+                            data.as_ref(),
+                            &overflow_state_bg,
+                            ProcessStreamKind::Stdout,
+                        ) {
                             break;
                         }
                     }
                     ChannelMsg::ExtendedData { data, ext: 1 } => {
-                        if let Err(err) = stderr_tx.try_send(data.as_ref().to_vec())
-                            && matches!(err, TrySendError::Closed(_))
-                        {
+                        if !forward_process_output_chunk(
+                            &stderr_tx,
+                            data.as_ref(),
+                            &overflow_state_bg,
+                            ProcessStreamKind::Stderr,
+                        ) {
                             break;
                         }
                     }
                     ChannelMsg::ExtendedData { data, .. } => {
-                        if let Err(err) = stdout_tx.try_send(data.as_ref().to_vec())
-                            && matches!(err, TrySendError::Closed(_))
-                        {
+                        if !forward_process_output_chunk(
+                            &stdout_tx,
+                            data.as_ref(),
+                            &overflow_state_bg,
+                            ProcessStreamKind::Stdout,
+                        ) {
                             break;
                         }
                     }
@@ -616,8 +635,44 @@ impl Kaos for SshKaos {
             null_stdout: QueueReader::empty(),
             null_stderr: QueueReader::empty(),
             exit_code_rx,
+            overflow_state,
             write_half,
         }))
+    }
+}
+
+#[derive(Default)]
+struct ProcessOutputOverflowState {
+    stdout_dropped_chunks: AtomicU64,
+    stdout_dropped_bytes: AtomicU64,
+    stderr_dropped_chunks: AtomicU64,
+    stderr_dropped_bytes: AtomicU64,
+}
+
+impl ProcessOutputOverflowState {
+    fn record_drop(&self, stream: ProcessStreamKind, bytes: usize) {
+        let bytes = bytes as u64;
+        match stream {
+            ProcessStreamKind::Stdout => {
+                self.stdout_dropped_chunks.fetch_add(1, Ordering::Relaxed);
+                self.stdout_dropped_bytes
+                    .fetch_add(bytes, Ordering::Relaxed);
+            }
+            ProcessStreamKind::Stderr => {
+                self.stderr_dropped_chunks.fetch_add(1, Ordering::Relaxed);
+                self.stderr_dropped_bytes
+                    .fetch_add(bytes, Ordering::Relaxed);
+            }
+        }
+    }
+
+    fn snapshot(&self) -> ProcessOutputOverflow {
+        ProcessOutputOverflow {
+            stdout_dropped_chunks: self.stdout_dropped_chunks.load(Ordering::Relaxed),
+            stdout_dropped_bytes: self.stdout_dropped_bytes.load(Ordering::Relaxed),
+            stderr_dropped_chunks: self.stderr_dropped_chunks.load(Ordering::Relaxed),
+            stderr_dropped_bytes: self.stderr_dropped_bytes.load(Ordering::Relaxed),
+        }
     }
 }
 
@@ -628,7 +683,24 @@ struct SshProcess {
     null_stdout: QueueReader,
     null_stderr: QueueReader,
     exit_code_rx: watch::Receiver<Option<i32>>,
+    overflow_state: Arc<ProcessOutputOverflowState>,
     write_half: Arc<AsyncMutex<Option<russh::ChannelWriteHalf<client::Msg>>>>,
+}
+
+fn forward_process_output_chunk(
+    tx: &mpsc::Sender<Vec<u8>>,
+    data: &[u8],
+    overflow_state: &ProcessOutputOverflowState,
+    stream: ProcessStreamKind,
+) -> bool {
+    match tx.try_send(data.to_vec()) {
+        Ok(()) => true,
+        Err(TrySendError::Closed(_)) => false,
+        Err(TrySendError::Full(chunk)) => {
+            overflow_state.record_drop(stream, chunk.len());
+            true
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -690,6 +762,11 @@ impl KaosProcess for SshProcess {
         self.stderr
             .take()
             .map(|stream| Box::new(stream) as Box<dyn AsyncReadable>)
+    }
+
+    fn output_overflow_summary(&self) -> Option<ProcessOutputOverflow> {
+        let summary = self.overflow_state.snapshot();
+        summary.has_drops().then_some(summary)
     }
 }
 

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -1202,6 +1202,11 @@ fn sftp_error(err: SftpError) -> anyhow::Error {
 
 fn expand_home(path: impl AsRef<str>) -> PathBuf {
     let path = path.as_ref();
+    if path == "~"
+        && let Some(home) = dirs::home_dir()
+    {
+        return home;
+    }
     if let Some(stripped) = path.strip_prefix("~/")
         && let Some(home) = dirs::home_dir()
     {

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -1,0 +1,1271 @@
+use std::collections::{HashSet, VecDeque};
+use std::fmt::Write as _;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Result, anyhow, bail};
+use russh::keys::known_hosts::learn_known_hosts_path;
+use russh::keys::{
+    PrivateKeyWithHashAlg, check_known_hosts_path, decode_secret_key, load_secret_key,
+};
+use russh::{ChannelMsg, Sig, client};
+use russh_sftp::client::SftpSession;
+use russh_sftp::client::error::Error as SftpError;
+use russh_sftp::protocol::{OpenFlags, StatusCode};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::{Mutex as AsyncMutex, Notify, mpsc};
+use typed_path::Utf8TypedPathBuf;
+
+use crate::{
+    AsyncReadable, AsyncWritable, Kaos, KaosPath, KaosPathStyle, KaosPlatform, KaosProcess,
+    LineStream, StatResult, StrOrKaosPath, line_stream::line_stream_from_async_read,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SshHostKeyPolicy {
+    Strict,
+    #[default]
+    AcceptNew,
+    Insecure,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SshKaosOptions {
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub key_contents: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub known_hosts_path: Option<String>,
+    #[serde(default)]
+    pub host_key_policy: SshHostKeyPolicy,
+    #[serde(default = "default_connect_timeout_seconds")]
+    pub connect_timeout_seconds: u64,
+}
+
+const fn default_port() -> u16 {
+    22
+}
+
+const fn default_connect_timeout_seconds() -> u64 {
+    15
+}
+
+const MAX_AGENT_IDENTITIES_TO_TRY: usize = 8;
+const PROCESS_OUTPUT_QUEUE_CAPACITY: usize = 64;
+
+impl SshKaosOptions {
+    fn known_hosts_path(&self) -> PathBuf {
+        let configured = self
+            .known_hosts_path
+            .clone()
+            .unwrap_or_else(|| "~/.kimi/known_hosts".to_string());
+        expand_home(&configured)
+    }
+}
+
+#[derive(Clone)]
+pub struct SshKaos {
+    state: Arc<SshState>,
+}
+
+struct SshState {
+    handle: AsyncMutex<client::Handle<SshClientHandler>>,
+    sftp: SftpSession,
+    home: KaosPath,
+    cwd: Mutex<KaosPath>,
+    platform: KaosPlatform,
+    storage_name: String,
+}
+
+struct SshClientHandler {
+    host: String,
+    port: u16,
+    host_key_policy: SshHostKeyPolicy,
+    known_hosts_path: PathBuf,
+}
+
+impl client::Handler for SshClientHandler {
+    type Error = anyhow::Error;
+
+    async fn check_server_key(
+        &mut self,
+        server_public_key: &russh::keys::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        match self.host_key_policy {
+            SshHostKeyPolicy::Insecure => Ok(true),
+            SshHostKeyPolicy::Strict => {
+                let matched = check_known_hosts_path(
+                    &self.host,
+                    self.port,
+                    server_public_key,
+                    &self.known_hosts_path,
+                )?;
+                if matched {
+                    Ok(true)
+                } else {
+                    bail!(
+                        "Host key for {}:{} is not trusted (policy: strict).",
+                        self.host,
+                        self.port
+                    );
+                }
+            }
+            SshHostKeyPolicy::AcceptNew => {
+                match check_known_hosts_path(
+                    &self.host,
+                    self.port,
+                    server_public_key,
+                    &self.known_hosts_path,
+                ) {
+                    Ok(true) => Ok(true),
+                    Ok(false) => {
+                        learn_known_hosts_path(
+                            &self.host,
+                            self.port,
+                            server_public_key,
+                            &self.known_hosts_path,
+                        )?;
+                        Ok(true)
+                    }
+                    Err(russh::keys::Error::KeyChanged { line }) => bail!(
+                        "Host key changed for {}:{} (known_hosts line {}).",
+                        self.host,
+                        self.port,
+                        line
+                    ),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    }
+}
+
+impl SshKaos {
+    pub async fn connect(options: SshKaosOptions) -> Result<Self> {
+        if options.host.trim().is_empty() {
+            bail!("SSH host cannot be empty");
+        }
+
+        let host = options.host.clone();
+        let port = options.port;
+        let username = options
+            .username
+            .clone()
+            .unwrap_or_else(default_ssh_username);
+        let known_hosts_path = options.known_hosts_path();
+        if let Some(parent) = known_hosts_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let connect_timeout = Duration::from_secs(options.connect_timeout_seconds);
+        let deadline = tokio::time::Instant::now() + connect_timeout;
+
+        let config = Arc::new(client::Config {
+            // Keep session idle behavior independent from connection timeout.
+            inactivity_timeout: None,
+            ..Default::default()
+        });
+        let handler = SshClientHandler {
+            host: host.clone(),
+            port,
+            host_key_policy: options.host_key_policy,
+            known_hosts_path,
+        };
+
+        let (mut handle, sftp, home, cwd) = tokio::time::timeout_at(deadline, async {
+            let mut handle = client::connect(config, (host.as_str(), port), handler).await?;
+            authenticate(&mut handle, &username, &options).await?;
+
+            let sftp_channel = handle.channel_open_session().await?;
+            sftp_channel.request_subsystem(true, "sftp").await?;
+            let sftp = SftpSession::new(sftp_channel.into_stream()).await?;
+
+            let home = KaosPath::from_style(
+                KaosPathStyle::Posix,
+                sftp.canonicalize(".").await.map_err(sftp_error)?,
+            );
+            let cwd = if let Some(cwd) = options.cwd.as_deref() {
+                let resolved = resolve_absolute_posix(&home, cwd);
+                let canonical = sftp.canonicalize(resolved).await.map_err(sftp_error)?;
+                let attrs = sftp
+                    .metadata(canonical.as_str())
+                    .await
+                    .map_err(sftp_error)?;
+                if !attrs.is_dir() {
+                    bail!("Configured SSH cwd is not a directory: {canonical}");
+                }
+                KaosPath::from_style(KaosPathStyle::Posix, canonical)
+            } else {
+                home.clone()
+            };
+            Ok::<_, anyhow::Error>((handle, sftp, home, cwd))
+        })
+        .await
+        .map_err(|_| {
+            anyhow!(
+                "Timed out establishing SSH session to {}:{} after {}s",
+                host,
+                port,
+                options.connect_timeout_seconds
+            )
+        })??;
+
+        let platform = detect_remote_platform_with_deadline(&mut handle, deadline).await?;
+        let storage_name = build_storage_name(&host, port, &username);
+
+        Ok(Self {
+            state: Arc::new(SshState {
+                handle: AsyncMutex::new(handle),
+                sftp,
+                home,
+                cwd: Mutex::new(cwd),
+                platform,
+                storage_name,
+            }),
+        })
+    }
+
+    fn normalize_posix(path: &str) -> String {
+        Utf8TypedPathBuf::from_unix(path).normalize().to_string()
+    }
+
+    fn resolve_path(&self, path: &KaosPath) -> KaosPath {
+        let normalized = KaosPath::from_style(KaosPathStyle::Posix, path.to_string_lossy());
+        if normalized.is_absolute() {
+            return KaosPath::from_style(
+                KaosPathStyle::Posix,
+                Self::normalize_posix(normalized.as_str()),
+            );
+        }
+
+        let cwd = self
+            .state
+            .cwd
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        cwd.joinpath(normalized.as_str()).canonical()
+    }
+}
+
+#[async_trait::async_trait]
+impl Kaos for SshKaos {
+    fn name(&self) -> &str {
+        "ssh"
+    }
+
+    fn storage_name(&self) -> String {
+        self.state.storage_name.clone()
+    }
+
+    fn platform(&self) -> KaosPlatform {
+        self.state.platform.clone()
+    }
+
+    fn path_style(&self) -> KaosPathStyle {
+        KaosPathStyle::Posix
+    }
+
+    fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath {
+        let raw = match path {
+            StrOrKaosPath::Str(s) => *s,
+            StrOrKaosPath::KaosPath(p) => p.as_str(),
+        };
+        KaosPath::from_style(KaosPathStyle::Posix, Self::normalize_posix(raw))
+    }
+
+    fn home(&self) -> KaosPath {
+        self.state.home.clone()
+    }
+
+    fn cwd(&self) -> KaosPath {
+        self.state
+            .cwd
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    async fn chdir(&self, path: &KaosPath) -> Result<()> {
+        let resolved = self.resolve_path(path);
+        let canonical = self
+            .state
+            .sftp
+            .canonicalize(resolved.as_str())
+            .await
+            .map_err(sftp_error)?;
+        let attrs = self
+            .state
+            .sftp
+            .metadata(canonical.as_str())
+            .await
+            .map_err(sftp_error)?;
+        if !attrs.is_dir() {
+            bail!("Not a directory: {}", canonical);
+        }
+        *self
+            .state
+            .cwd
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+            KaosPath::from_style(KaosPathStyle::Posix, canonical);
+        Ok(())
+    }
+
+    async fn stat(&self, path: &KaosPath, follow_symlinks: bool) -> Result<StatResult> {
+        let resolved = self.resolve_path(path);
+        let attrs = if follow_symlinks {
+            self.state
+                .sftp
+                .metadata(resolved.as_str())
+                .await
+                .map_err(sftp_error)?
+        } else {
+            self.state
+                .sftp
+                .symlink_metadata(resolved.as_str())
+                .await
+                .map_err(sftp_error)?
+        };
+
+        let st_mode = attrs.permissions.unwrap_or(0);
+        Ok(StatResult {
+            st_mode,
+            st_ino: 0,
+            st_dev: 0,
+            st_nlink: 0,
+            st_uid: attrs.uid.unwrap_or(0),
+            st_gid: attrs.gid.unwrap_or(0),
+            st_size: attrs.size.unwrap_or(0),
+            st_atime: attrs.atime.unwrap_or(0) as f64,
+            st_mtime: attrs.mtime.unwrap_or(0) as f64,
+            st_ctime: attrs.mtime.unwrap_or(0) as f64,
+        })
+    }
+
+    async fn iterdir(&self, path: &KaosPath) -> Result<Vec<KaosPath>> {
+        let resolved = self.resolve_path(path);
+        let mut entries = Vec::new();
+        let dir = self
+            .state
+            .sftp
+            .read_dir(resolved.as_str())
+            .await
+            .map_err(sftp_error)?;
+        for entry in dir {
+            let full = resolved.joinpath(&entry.file_name());
+            entries.push(full);
+        }
+        Ok(entries)
+    }
+
+    async fn glob(
+        &self,
+        path: &KaosPath,
+        pattern: &str,
+        case_sensitive: bool,
+    ) -> Result<Vec<KaosPath>> {
+        if !case_sensitive {
+            bail!("Case insensitive glob is not supported in current environment");
+        }
+        let normalized_pattern = normalize_glob_pattern(pattern);
+        let resolved = self.resolve_path(path);
+        let matcher = glob::Pattern::new(&normalized_pattern).map_err(|err| anyhow!(err))?;
+        let options = glob::MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: true,
+            require_literal_leading_dot: true,
+        };
+        let traversal_plan = GlobTraversalPlan::from_pattern(&normalized_pattern)?;
+
+        let mut stack = vec![(resolved.clone(), 0usize)];
+        let mut matched = Vec::new();
+
+        while let Some((dir, dir_depth)) = stack.pop() {
+            let entries = self
+                .state
+                .sftp
+                .read_dir(dir.as_str())
+                .await
+                .map_err(sftp_error)?;
+
+            for entry in entries {
+                let name = entry.file_name();
+                // russh-sftp currently filters "." and ".." in ReadDir, but keep a guard
+                // here to remain correct if dependency behavior changes.
+                if name == "." || name == ".." {
+                    continue;
+                }
+                let full = dir.joinpath(&name);
+                let relative = full
+                    .relative_to(&resolved)
+                    .unwrap_or_else(|_| KaosPath::from_style(KaosPathStyle::Posix, &name));
+                let rel = relative.to_string_lossy();
+                if matcher.matches_with(&rel, options) {
+                    matched.push(full.clone());
+                }
+                let next_depth = dir_depth + 1;
+                if entry.file_type().is_dir()
+                    && traversal_plan.should_descend(&rel, next_depth, &options)
+                {
+                    stack.push((full, next_depth));
+                }
+            }
+        }
+
+        Ok(matched)
+    }
+
+    async fn read_bytes(&self, path: &KaosPath, limit: Option<usize>) -> Result<Vec<u8>> {
+        let resolved = self.resolve_path(path);
+        let mut data = self
+            .state
+            .sftp
+            .read(resolved.as_str())
+            .await
+            .map_err(sftp_error)?;
+        if let Some(n) = limit {
+            data.truncate(n);
+        }
+        Ok(data)
+    }
+
+    async fn read_text(&self, path: &KaosPath) -> Result<String> {
+        let bytes = self.read_bytes(path, None).await?;
+        String::from_utf8(bytes).map_err(|err| anyhow!("File is not valid UTF-8: {err}"))
+    }
+
+    async fn read_lines(&self, path: &KaosPath) -> Result<Vec<String>> {
+        let text = self.read_text(path).await?;
+        let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+        Ok(normalized
+            .split_inclusive('\n')
+            .map(str::to_string)
+            .collect())
+    }
+
+    async fn read_lines_stream(&self, path: &KaosPath) -> Result<LineStream> {
+        let resolved = self.resolve_path(path);
+        let file = self
+            .state
+            .sftp
+            .open(resolved.as_str())
+            .await
+            .map_err(sftp_error)?;
+        Ok(line_stream_from_async_read(file))
+    }
+
+    async fn write_bytes(&self, path: &KaosPath, data: &[u8]) -> Result<usize> {
+        let resolved = self.resolve_path(path);
+        let mut file = self
+            .state
+            .sftp
+            .open_with_flags(
+                resolved.as_str(),
+                OpenFlags::CREATE | OpenFlags::TRUNCATE | OpenFlags::WRITE,
+            )
+            .await
+            .map_err(sftp_error)?;
+        file.write_all(data).await?;
+        file.shutdown().await?;
+        Ok(data.len())
+    }
+
+    async fn write_text(&self, path: &KaosPath, data: &str, append: bool) -> Result<usize> {
+        let resolved = self.resolve_path(path);
+        let flags = if append {
+            OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::APPEND
+        } else {
+            OpenFlags::CREATE | OpenFlags::WRITE | OpenFlags::TRUNCATE
+        };
+        let mut file = self
+            .state
+            .sftp
+            .open_with_flags(resolved.as_str(), flags)
+            .await
+            .map_err(sftp_error)?;
+        file.write_all(data.as_bytes()).await?;
+        file.shutdown().await?;
+        Ok(data.len())
+    }
+
+    async fn chmod(&self, path: &KaosPath, mode: u32) -> Result<()> {
+        let resolved = self.resolve_path(path);
+        let mut attrs = self
+            .state
+            .sftp
+            .metadata(resolved.as_str())
+            .await
+            .map_err(sftp_error)?;
+        let file_type_bits = attrs.permissions.unwrap_or(0) & 0o170000;
+        attrs.permissions = Some(file_type_bits | (mode & 0o7777));
+        self.state
+            .sftp
+            .set_metadata(resolved.as_str(), attrs)
+            .await
+            .map_err(sftp_error)?;
+        Ok(())
+    }
+
+    async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> Result<()> {
+        let resolved = self.resolve_path(path);
+        if !parents {
+            return mkdir_once(&self.state.sftp, resolved.as_str(), exist_ok).await;
+        }
+
+        let normalized = resolved.canonical();
+        let mut current = KaosPath::from_style(KaosPathStyle::Posix, "/");
+        let normalized_str = normalized.to_string_lossy();
+        let components = normalized_str
+            .split('/')
+            .filter(|part| !part.is_empty())
+            .collect::<Vec<_>>();
+
+        for (idx, component) in components.iter().enumerate() {
+            current = current.joinpath(component);
+            let allow_existing = if idx + 1 == components.len() {
+                exist_ok
+            } else {
+                true
+            };
+            mkdir_once(&self.state.sftp, current.as_str(), allow_existing).await?;
+        }
+        Ok(())
+    }
+
+    async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>> {
+        if args.is_empty() {
+            bail!("missing command");
+        }
+
+        let quoted = args
+            .iter()
+            .map(|arg| shell_quote(arg))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let cwd = self.cwd();
+        let command = format!("cd {} && {}", shell_quote(cwd.as_str()), quoted);
+
+        let handle = self.state.handle.lock().await;
+        let channel = handle.channel_open_session().await?;
+        let (mut read_half, write_half) = channel.split();
+        write_half.exec(true, command).await?;
+        let write_half = Arc::new(AsyncMutex::new(Some(write_half)));
+        let stdin_writer = ChannelStdin {
+            write_half: Arc::clone(&write_half),
+        };
+
+        let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(PROCESS_OUTPUT_QUEUE_CAPACITY);
+        let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(PROCESS_OUTPUT_QUEUE_CAPACITY);
+        let exit_state = Arc::new(ProcessExitState::default());
+        let exit_state_bg = Arc::clone(&exit_state);
+
+        tokio::spawn(async move {
+            let mut exit_code: Option<i32> = None;
+            while let Some(msg) = read_half.wait().await {
+                match msg {
+                    ChannelMsg::Data { data } => {
+                        if let Err(err) = stdout_tx.try_send(data.as_ref().to_vec())
+                            && matches!(err, TrySendError::Closed(_))
+                        {
+                            break;
+                        }
+                    }
+                    ChannelMsg::ExtendedData { data, ext: 1 } => {
+                        if let Err(err) = stderr_tx.try_send(data.as_ref().to_vec())
+                            && matches!(err, TrySendError::Closed(_))
+                        {
+                            break;
+                        }
+                    }
+                    ChannelMsg::ExtendedData { data, .. } => {
+                        if let Err(err) = stdout_tx.try_send(data.as_ref().to_vec())
+                            && matches!(err, TrySendError::Closed(_))
+                        {
+                            break;
+                        }
+                    }
+                    ChannelMsg::ExitStatus { exit_status } => {
+                        exit_code = Some(exit_status as i32);
+                    }
+                    ChannelMsg::Close => break,
+                    ChannelMsg::Eof => {}
+                    _ => {}
+                }
+            }
+            *exit_state_bg
+                .code
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(exit_code.unwrap_or(1));
+            exit_state_bg.notify.notify_waiters();
+        });
+
+        Ok(Box::new(SshProcess {
+            stdin: stdin_writer,
+            stdout: Some(QueueReader::new(stdout_rx)),
+            stderr: Some(QueueReader::new(stderr_rx)),
+            null_stdout: QueueReader::empty(),
+            null_stderr: QueueReader::empty(),
+            exit_state,
+            write_half,
+        }))
+    }
+}
+
+#[derive(Default)]
+struct ProcessExitState {
+    code: Mutex<Option<i32>>,
+    notify: Notify,
+}
+
+struct SshProcess {
+    stdin: ChannelStdin,
+    stdout: Option<QueueReader>,
+    stderr: Option<QueueReader>,
+    null_stdout: QueueReader,
+    null_stderr: QueueReader,
+    exit_state: Arc<ProcessExitState>,
+    write_half: Arc<AsyncMutex<Option<russh::ChannelWriteHalf<client::Msg>>>>,
+}
+
+#[async_trait::async_trait]
+impl KaosProcess for SshProcess {
+    fn pid(&self) -> u32 {
+        0
+    }
+
+    fn returncode(&mut self) -> Option<i32> {
+        *self
+            .exit_state
+            .code
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    async fn wait(&mut self) -> Result<i32> {
+        loop {
+            if let Some(code) = self.returncode() {
+                return Ok(code);
+            }
+            self.exit_state.notify.notified().await;
+        }
+    }
+
+    async fn kill(&mut self) -> Result<()> {
+        let mut lock = self.write_half.lock().await;
+        if let Some(write_half) = lock.as_ref() {
+            let _ = write_half.signal(Sig::TERM).await;
+            let _ = write_half.close().await;
+        }
+        *lock = None;
+        Ok(())
+    }
+
+    fn stdin(&mut self) -> &mut dyn AsyncWritable {
+        &mut self.stdin
+    }
+
+    fn stdout(&mut self) -> &mut dyn AsyncReadable {
+        self.stdout
+            .as_mut()
+            .map(|stream| stream as &mut dyn AsyncReadable)
+            .unwrap_or(&mut self.null_stdout)
+    }
+
+    fn stderr(&mut self) -> &mut dyn AsyncReadable {
+        self.stderr
+            .as_mut()
+            .map(|stream| stream as &mut dyn AsyncReadable)
+            .unwrap_or(&mut self.null_stderr)
+    }
+
+    fn take_stdout(&mut self) -> Option<Box<dyn AsyncReadable>> {
+        self.stdout
+            .take()
+            .map(|stream| Box::new(stream) as Box<dyn AsyncReadable>)
+    }
+
+    fn take_stderr(&mut self) -> Option<Box<dyn AsyncReadable>> {
+        self.stderr
+            .take()
+            .map(|stream| Box::new(stream) as Box<dyn AsyncReadable>)
+    }
+}
+
+struct ChannelStdin {
+    write_half: Arc<AsyncMutex<Option<russh::ChannelWriteHalf<client::Msg>>>>,
+}
+
+#[async_trait::async_trait]
+impl AsyncWritable for ChannelStdin {
+    async fn write(&mut self, data: &[u8]) -> Result<()> {
+        let lock = self.write_half.lock().await;
+        let Some(write_half) = lock.as_ref() else {
+            bail!("stdin is closed");
+        };
+        let mut writer = write_half.make_writer();
+        writer.write_all(data).await?;
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        let lock = self.write_half.lock().await;
+        if let Some(write_half) = lock.as_ref() {
+            let mut writer = write_half.make_writer();
+            writer.flush().await?;
+        }
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        let mut lock = self.write_half.lock().await;
+        if let Some(write_half) = lock.as_ref() {
+            let _ = write_half.eof().await;
+            let _ = write_half.close().await;
+        }
+        *lock = None;
+        Ok(())
+    }
+}
+
+struct QueueReader {
+    receiver: Option<mpsc::Receiver<Vec<u8>>>,
+    buffer: VecDeque<u8>,
+    eof: bool,
+}
+
+impl QueueReader {
+    fn new(receiver: mpsc::Receiver<Vec<u8>>) -> Self {
+        Self {
+            receiver: Some(receiver),
+            buffer: VecDeque::new(),
+            eof: false,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            receiver: None,
+            buffer: VecDeque::new(),
+            eof: true,
+        }
+    }
+
+    async fn fill_buffer(&mut self) {
+        while !self.eof && self.buffer.is_empty() {
+            self.recv_next_chunk().await;
+        }
+    }
+
+    async fn recv_next_chunk(&mut self) {
+        if self.eof {
+            return;
+        }
+        let Some(receiver) = self.receiver.as_mut() else {
+            self.eof = true;
+            return;
+        };
+        match receiver.recv().await {
+            Some(bytes) if !bytes.is_empty() => self.buffer.extend(bytes),
+            Some(_) => {}
+            None => {
+                self.eof = true;
+                self.receiver = None;
+            }
+        }
+    }
+}
+
+struct GlobTraversalPlan {
+    max_dir_depth: Option<usize>,
+    prefix_segment_patterns: Vec<glob::Pattern>,
+}
+
+impl GlobTraversalPlan {
+    fn from_pattern(pattern: &str) -> Result<Self> {
+        let segments: Vec<&str> = pattern.split('/').collect();
+        let first_globstar = segments.iter().position(|segment| *segment == "**");
+        let prefix_len = first_globstar.unwrap_or(segments.len());
+        let prefix_segment_patterns = segments
+            .iter()
+            .take(prefix_len)
+            .map(|segment| glob::Pattern::new(segment).map_err(|err| anyhow!(err)))
+            .collect::<Result<Vec<_>>>()?;
+        let max_dir_depth = if first_globstar.is_some() {
+            None
+        } else {
+            Some(segments.len().saturating_sub(1))
+        };
+
+        Ok(Self {
+            max_dir_depth,
+            prefix_segment_patterns,
+        })
+    }
+
+    fn should_descend(&self, rel_path: &str, depth: usize, options: &glob::MatchOptions) -> bool {
+        if let Some(max_dir_depth) = self.max_dir_depth
+            && depth > max_dir_depth
+        {
+            return false;
+        }
+
+        let prefix_check_len = depth.min(self.prefix_segment_patterns.len());
+        for (idx, segment) in rel_path.split('/').take(prefix_check_len).enumerate() {
+            if !self.prefix_segment_patterns[idx].matches_with(segment, *options) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[async_trait::async_trait]
+impl AsyncReadable for QueueReader {
+    async fn read(&mut self, n: usize) -> Result<Vec<u8>> {
+        if n == 0 {
+            return Ok(Vec::new());
+        }
+        self.fill_buffer().await;
+        if self.buffer.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::with_capacity(n.min(self.buffer.len()));
+        for _ in 0..n {
+            if let Some(byte) = self.buffer.pop_front() {
+                out.push(byte);
+            } else {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
+    async fn readline(&mut self) -> Result<Vec<u8>> {
+        loop {
+            if let Some(pos) = self.buffer.iter().position(|byte| *byte == b'\n') {
+                let mut out = Vec::with_capacity(pos + 1);
+                for _ in 0..=pos {
+                    if let Some(byte) = self.buffer.pop_front() {
+                        out.push(byte);
+                    }
+                }
+                return Ok(out);
+            }
+
+            self.recv_next_chunk().await;
+            if self.eof {
+                let mut out = Vec::with_capacity(self.buffer.len());
+                while let Some(byte) = self.buffer.pop_front() {
+                    out.push(byte);
+                }
+                return Ok(out);
+            }
+        }
+    }
+
+    fn is_eof(&self) -> bool {
+        self.eof && self.buffer.is_empty()
+    }
+}
+
+async fn authenticate(
+    handle: &mut client::Handle<SshClientHandler>,
+    username: &str,
+    options: &SshKaosOptions,
+) -> Result<()> {
+    let preferred_hash = handle.best_supported_rsa_hash().await?.flatten();
+
+    for key in &options.key_contents {
+        let key = decode_secret_key(key, None)?;
+        let key = PrivateKeyWithHashAlg::new(Arc::new(key), preferred_hash);
+        let result = handle.authenticate_publickey(username, key).await?;
+        if result.success() {
+            return Ok(());
+        }
+    }
+
+    let mut explicit_key_paths = HashSet::new();
+    for path in &options.key_paths {
+        let path = expand_home(path);
+        explicit_key_paths.insert(path.clone());
+        let key = load_secret_key(&path, None)?;
+        let key = PrivateKeyWithHashAlg::new(Arc::new(key), preferred_hash);
+        let result = handle.authenticate_publickey(username, key).await?;
+        if result.success() {
+            return Ok(());
+        }
+    }
+
+    if let Some(password) = options.password.as_deref() {
+        let result = handle.authenticate_password(username, password).await?;
+        if result.success() {
+            return Ok(());
+        }
+    }
+
+    if try_authenticate_with_agent(handle, username, preferred_hash).await? {
+        return Ok(());
+    }
+
+    for path in default_private_key_paths() {
+        if explicit_key_paths.contains(&path) || !path.is_file() {
+            continue;
+        }
+        let Ok(key) = load_secret_key(&path, None) else {
+            continue;
+        };
+        let key = PrivateKeyWithHashAlg::new(Arc::new(key), preferred_hash);
+        let result = handle.authenticate_publickey(username, key).await?;
+        if result.success() {
+            return Ok(());
+        }
+    }
+
+    bail!("SSH authentication failed for user `{username}`");
+}
+
+#[cfg(unix)]
+async fn try_authenticate_with_agent(
+    handle: &mut client::Handle<SshClientHandler>,
+    username: &str,
+    preferred_hash: Option<russh::keys::ssh_key::HashAlg>,
+) -> Result<bool> {
+    let mut agent = match russh::keys::agent::client::AgentClient::connect_env().await {
+        Ok(agent) => agent,
+        Err(_) => return Ok(false),
+    };
+    let identities = match agent.request_identities().await {
+        Ok(identities) => identities,
+        Err(_) => return Ok(false),
+    };
+
+    // Keep attempts bounded to reduce server-side auth-attempt exhaustion.
+    for key in identities.into_iter().take(MAX_AGENT_IDENTITIES_TO_TRY) {
+        let result = handle
+            .authenticate_publickey_with(username, key, preferred_hash, &mut agent)
+            .await?;
+        if result.success() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(not(unix))]
+async fn try_authenticate_with_agent(
+    _handle: &mut client::Handle<SshClientHandler>,
+    _username: &str,
+    _preferred_hash: Option<russh::keys::ssh_key::HashAlg>,
+) -> Result<bool> {
+    Ok(false)
+}
+
+async fn detect_remote_platform(
+    handle: &mut client::Handle<SshClientHandler>,
+) -> Result<KaosPlatform> {
+    let (os_code, os_out, os_err) = exec_capture(handle, "uname -s").await?;
+    if os_code != 0 {
+        bail!("Failed to detect remote OS with `uname -s`: {os_err}");
+    }
+    let os = normalize_os(&os_out);
+    if os != "linux" && os != "macos" {
+        bail!("Unsupported SSH remote OS `{os}`; only Linux and macOS targets are supported");
+    }
+
+    let (arch_code, arch_out, arch_err) = exec_capture(handle, "uname -m").await?;
+    if arch_code != 0 {
+        bail!("Failed to detect remote architecture with `uname -m`: {arch_err}");
+    }
+    let arch = normalize_arch(&arch_out);
+
+    let libc = if os == "linux" {
+        match exec_capture(handle, "ldd --version 2>&1 | head -n1").await {
+            Ok((0, out, _)) => detect_libc(&out),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    Ok(KaosPlatform {
+        os,
+        arch,
+        abi: None,
+        libc,
+    })
+}
+
+async fn detect_remote_platform_with_deadline(
+    handle: &mut client::Handle<SshClientHandler>,
+    deadline: tokio::time::Instant,
+) -> Result<KaosPlatform> {
+    if tokio::time::Instant::now() >= deadline {
+        bail!("Timed out before remote platform detection could start");
+    }
+    match tokio::time::timeout_at(deadline, detect_remote_platform(handle)).await {
+        Ok(platform) => platform,
+        Err(_) => bail!("Timed out while detecting remote platform"),
+    }
+}
+
+async fn exec_capture(
+    handle: &mut client::Handle<SshClientHandler>,
+    command: &str,
+) -> Result<(i32, String, String)> {
+    let mut channel = handle.channel_open_session().await?;
+    channel.exec(true, command).await?;
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut code: Option<i32> = None;
+    while let Some(msg) = channel.wait().await {
+        match msg {
+            ChannelMsg::Data { data } => stdout.extend_from_slice(data.as_ref()),
+            ChannelMsg::ExtendedData { data, ext: 1 } => stderr.extend_from_slice(data.as_ref()),
+            ChannelMsg::ExtendedData { data, .. } => stdout.extend_from_slice(data.as_ref()),
+            ChannelMsg::ExitStatus { exit_status } => code = Some(exit_status as i32),
+            ChannelMsg::Close => break,
+            _ => {}
+        }
+    }
+
+    Ok((
+        code.unwrap_or(1),
+        String::from_utf8_lossy(&stdout).trim().to_string(),
+        String::from_utf8_lossy(&stderr).trim().to_string(),
+    ))
+}
+
+async fn mkdir_once(sftp: &SftpSession, path: &str, exist_ok: bool) -> Result<()> {
+    match sftp.create_dir(path).await {
+        Ok(()) => Ok(()),
+        Err(SftpError::Status(status))
+            if exist_ok
+                && matches!(
+                    status.status_code,
+                    StatusCode::Failure | StatusCode::NoSuchFile
+                ) =>
+        {
+            match sftp.metadata(path).await {
+                Ok(attrs) if attrs.is_dir() => Ok(()),
+                Ok(_) => bail!("Path exists but is not a directory: {path}"),
+                Err(err) => Err(sftp_error(err)),
+            }
+        }
+        Err(err) => Err(sftp_error(err)),
+    }
+}
+
+fn normalize_os(raw: &str) -> String {
+    let lowered = raw.trim().to_ascii_lowercase();
+    if lowered.contains("darwin") {
+        "macos".to_string()
+    } else if lowered.contains("linux") || lowered.is_empty() {
+        "linux".to_string()
+    } else {
+        lowered
+    }
+}
+
+fn normalize_arch(raw: &str) -> String {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "x86_64" | "amd64" => "x86_64".to_string(),
+        "aarch64" | "arm64" => "aarch64".to_string(),
+        "x86" | "i386" | "i686" => "x86".to_string(),
+        other if !other.is_empty() => other.to_string(),
+        _ => "x86_64".to_string(),
+    }
+}
+
+fn detect_libc(raw: &str) -> Option<String> {
+    let lowered = raw.to_ascii_lowercase();
+    if lowered.contains("musl") {
+        Some("musl".to_string())
+    } else if lowered.contains("glibc") || lowered.contains("gnu libc") {
+        Some("gnu".to_string())
+    } else {
+        None
+    }
+}
+
+fn resolve_absolute_posix(base: &KaosPath, target: &str) -> String {
+    if target == "~" {
+        base.as_str().to_string()
+    } else if let Some(stripped) = target.strip_prefix("~/") {
+        Utf8TypedPathBuf::from_unix(base.as_str())
+            .join(stripped)
+            .normalize()
+            .to_string()
+    } else if target.starts_with('/') {
+        Utf8TypedPathBuf::from_unix(target).normalize().to_string()
+    } else {
+        Utf8TypedPathBuf::from_unix(base.as_str())
+            .join(target)
+            .normalize()
+            .to_string()
+    }
+}
+
+fn normalize_glob_pattern(pattern: &str) -> String {
+    pattern.trim_start_matches("./").to_string()
+}
+
+fn shell_quote(arg: &str) -> String {
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+    format!("'{}'", arg.replace('\'', r#"'"'"'"#))
+}
+
+fn sftp_error(err: SftpError) -> anyhow::Error {
+    anyhow!("SFTP error: {err}")
+}
+
+fn expand_home(path: impl AsRef<str>) -> PathBuf {
+    let path = path.as_ref();
+    if let Some(stripped) = path.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(stripped);
+    }
+    PathBuf::from(path)
+}
+
+fn default_private_key_paths() -> Vec<PathBuf> {
+    let Some(home) = dirs::home_dir() else {
+        return Vec::new();
+    };
+    let ssh_dir = home.join(".ssh");
+    [
+        "id_ed25519",
+        "id_ed25519_sk",
+        "id_ecdsa",
+        "id_ecdsa_sk",
+        "id_rsa",
+        "id_dsa",
+    ]
+    .into_iter()
+    .map(|name| ssh_dir.join(name))
+    .collect()
+}
+
+fn default_ssh_username() -> String {
+    std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "root".to_string())
+}
+
+fn build_storage_name(host: &str, port: u16, username: &str) -> String {
+    let normalized_host = host.to_ascii_lowercase();
+    let host_hint = normalized_host
+        .chars()
+        .map(|ch| match ch {
+            'a'..='z' | '0'..='9' => ch,
+            _ => '-',
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    let host_hint = if host_hint.is_empty() {
+        "host".to_string()
+    } else {
+        host_hint.chars().take(24).collect()
+    };
+
+    let identity = format!("{username}@{normalized_host}:{port}");
+    let mut hasher = Sha256::new();
+    hasher.update(identity.as_bytes());
+    let digest = hasher.finalize();
+    let mut suffix = String::with_capacity(32);
+    for byte in digest.iter().take(16) {
+        let _ = write!(&mut suffix, "{byte:02x}");
+    }
+
+    format!("ssh_{host_hint}_{suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        GlobTraversalPlan, build_storage_name, normalize_glob_pattern, resolve_absolute_posix,
+    };
+    use crate::{KaosPath, KaosPathStyle};
+
+    #[test]
+    fn storage_name_is_deterministic() {
+        let first = build_storage_name("a-b.example.com", 22, "ops");
+        let second = build_storage_name("a-b.example.com", 22, "ops");
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn storage_name_distinguishes_common_host_variants() {
+        let dashed = build_storage_name("a-b.example.com", 22, "ops");
+        let dotted = build_storage_name("a.b-example.com", 22, "ops");
+        assert_ne!(dashed, dotted);
+    }
+
+    #[test]
+    fn storage_name_ignores_host_case() {
+        let lower = build_storage_name("example.com", 22, "ops");
+        let mixed = build_storage_name("Example.COM", 22, "ops");
+        assert_eq!(lower, mixed);
+    }
+
+    #[test]
+    fn resolve_absolute_posix_expands_home_marker() {
+        let home = KaosPath::from_style(KaosPathStyle::Posix, "/home/alice");
+        assert_eq!(resolve_absolute_posix(&home, "~"), "/home/alice");
+        assert_eq!(
+            resolve_absolute_posix(&home, "~/project"),
+            "/home/alice/project"
+        );
+    }
+
+    #[test]
+    fn glob_plan_blocks_recursion_for_shallow_patterns() {
+        let plan = GlobTraversalPlan::from_pattern("*.rs").expect("valid pattern");
+        let options = glob::MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: true,
+            require_literal_leading_dot: true,
+        };
+
+        assert!(!plan.should_descend("src", 1, &options));
+    }
+
+    #[test]
+    fn glob_plan_keeps_prefix_pruning_with_globstar() {
+        let plan = GlobTraversalPlan::from_pattern("src/**/test_*.rs").expect("valid pattern");
+        let options = glob::MatchOptions {
+            case_sensitive: true,
+            require_literal_separator: true,
+            require_literal_leading_dot: true,
+        };
+
+        assert!(plan.should_descend("src", 1, &options));
+        assert!(plan.should_descend("src/lib", 2, &options));
+        assert!(!plan.should_descend("docs", 1, &options));
+    }
+
+    #[test]
+    fn normalize_glob_pattern_trims_current_dir_prefix() {
+        assert_eq!(normalize_glob_pattern("./*.rs"), "*.rs");
+        assert_eq!(normalize_glob_pattern("./src/**/*.rs"), "src/**/*.rs");
+        assert_eq!(normalize_glob_pattern("*.rs"), "*.rs");
+    }
+}

--- a/kimi-agent/src/app.rs
+++ b/kimi-agent/src/app.rs
@@ -178,6 +178,7 @@ impl KimiCLI {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let tx_for_ui = tx.clone();
         let work_dir = self.runtime.session.work_dir.clone();
+        let original_cwd = KaosPath::cwd();
         let wire_file = self.runtime.session.wire_file();
 
         let ui_loop = move |wire: Arc<crate::wire::Wire>| {
@@ -200,6 +201,7 @@ impl KimiCLI {
             Some(wire_file),
         )
         .await;
+        let _ = kaos::chdir(&original_cwd).await;
 
         drop(tx);
         let mut messages = Vec::new();

--- a/kimi-agent/src/cli/mod.rs
+++ b/kimi-agent/src/cli/mod.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
@@ -6,7 +7,7 @@ use kaos::KaosPath;
 
 use crate::agentspec::{default_agent_file, okabe_agent_file};
 use crate::app::{ConfigInput, CreateOptions, KimiCLI};
-use crate::config::load_config_from_string;
+use crate::config::{Config, KaosConfig, load_config, load_config_from_string};
 use crate::constant::VERSION;
 use crate::metadata::{load_metadata, save_metadata};
 use crate::session::Session;
@@ -43,7 +44,7 @@ pub struct Cli {
         value_name = "PATH",
         help = "Working directory for the agent. Default: current directory."
     )]
-    work_dir: Option<PathBuf>,
+    work_dir: Option<String>,
 
     #[arg(
         long = "session",
@@ -137,7 +138,7 @@ pub struct Cli {
         value_name = "PATH",
         help = "Path to the skills directory. Overrides discovery."
     )]
-    skills_dir: Option<PathBuf>,
+    skills_dir: Option<String>,
 
     #[arg(
         long = "max-steps-per-turn",
@@ -175,6 +176,24 @@ enum Commands {
     Mcp(mcp::McpArgs),
 }
 
+struct KaosScopeGuard {
+    token: Option<kaos::CurrentKaosToken>,
+}
+
+impl KaosScopeGuard {
+    fn new(token: kaos::CurrentKaosToken) -> Self {
+        Self { token: Some(token) }
+    }
+}
+
+impl Drop for KaosScopeGuard {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            kaos::reset_current_kaos(token);
+        }
+    }
+}
+
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
 
@@ -197,25 +216,19 @@ pub async fn run() -> Result<()> {
 
     validate_cli_args(&cli).await?;
 
-    let config_input = if let Some(config_string) = cli.config_string.as_ref() {
-        let config = load_config_from_string(config_string)
-            .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-        Some(ConfigInput::Inline(Box::new(config)))
-    } else {
-        cli.config_file
-            .as_ref()
-            .map(|config_file| ConfigInput::Path(config_file.clone()))
-    };
+    let config = load_effective_config(&cli).await?;
+    let _kaos_guard = init_current_kaos(&config).await?;
+    validate_runtime_paths(&cli).await?;
 
     let mcp_configs = mcp::load_mcp_configs(&cli.mcp_config_file, &cli.mcp_config).await?;
 
     let skills_dir = cli
         .skills_dir
         .as_ref()
-        .map(|path| KaosPath::unsafe_from_local_path(path));
+        .map(|path| cli_path_to_kaos_path(path));
 
     let work_dir = match cli.work_dir.as_ref() {
-        Some(path) => KaosPath::unsafe_from_local_path(path),
+        Some(path) => cli_path_to_kaos_path(path),
         None => KaosPath::cwd(),
     };
 
@@ -227,7 +240,7 @@ pub async fn run() -> Result<()> {
     let instance = KimiCLI::create(
         session,
         CreateOptions {
-            config: config_input,
+            config: Some(ConfigInput::Inline(Box::new(config))),
             model_name: cli.model_name.clone(),
             thinking,
             yolo: cli.yolo,
@@ -244,6 +257,61 @@ pub async fn run() -> Result<()> {
     let session = instance.session().clone();
     instance.run_wire_stdio().await?;
     post_run(&session).await?;
+    Ok(())
+}
+
+async fn load_effective_config(cli: &Cli) -> Result<Config> {
+    if let Some(config_string) = cli.config_string.as_ref() {
+        return load_config_from_string(config_string).map_err(anyhow::Error::new);
+    }
+    if let Some(config_file) = cli.config_file.as_ref() {
+        return load_config(Some(config_file))
+            .await
+            .map_err(anyhow::Error::new);
+    }
+    load_config(None).await.map_err(anyhow::Error::new)
+}
+
+async fn init_current_kaos(config: &Config) -> Result<KaosScopeGuard> {
+    let kaos: Arc<dyn kaos::Kaos> = match &config.kaos {
+        KaosConfig::Local => Arc::new(kaos::LocalKaos::new()),
+        KaosConfig::Ssh { options } => Arc::new(
+            kaos::SshKaos::connect(options.clone())
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to connect ssh kaos {}:{}",
+                        options.host, options.port
+                    )
+                })?,
+        ),
+    };
+    Ok(KaosScopeGuard::new(kaos::set_current_kaos(kaos)))
+}
+
+fn cli_path_to_kaos_path(path: &str) -> KaosPath {
+    KaosPath::new(path)
+}
+
+async fn validate_runtime_paths(cli: &Cli) -> Result<()> {
+    if let Some(work_dir) = cli.work_dir.as_ref() {
+        ensure_kaos_dir_exists(&cli_path_to_kaos_path(work_dir), "work dir").await?;
+    }
+
+    if let Some(skills_dir) = cli.skills_dir.as_ref() {
+        ensure_kaos_dir_exists(&cli_path_to_kaos_path(skills_dir), "skills dir").await?;
+    }
+
+    Ok(())
+}
+
+async fn ensure_kaos_dir_exists(path: &KaosPath, label: &str) -> Result<()> {
+    if !path.exists(true).await {
+        anyhow::bail!("{label} does not exist: {}", path.to_string_lossy());
+    }
+    if !path.is_dir(true).await {
+        anyhow::bail!("{label} is not a directory: {}", path.to_string_lossy());
+    }
     Ok(())
 }
 
@@ -290,14 +358,6 @@ async fn validate_cli_args(cli: &Cli) -> Result<()> {
         anyhow::bail!("Config cannot be empty.");
     }
 
-    if let Some(work_dir) = cli.work_dir.as_ref() {
-        ensure_dir_exists(work_dir, "work dir").await?;
-    }
-
-    if let Some(skills_dir) = cli.skills_dir.as_ref() {
-        ensure_dir_exists(skills_dir, "skills dir").await?;
-    }
-
     if let Some(config_file) = cli.config_file.as_ref() {
         ensure_file_exists(config_file, "config file").await?;
     }
@@ -331,17 +391,7 @@ async fn validate_cli_args(cli: &Cli) -> Result<()> {
     Ok(())
 }
 
-async fn ensure_dir_exists(path: &PathBuf, label: &str) -> Result<()> {
-    let metadata = tokio::fs::metadata(path)
-        .await
-        .with_context(|| format!("{label} does not exist: {}", path.display()))?;
-    if !metadata.is_dir() {
-        anyhow::bail!("{label} is not a directory: {}", path.display());
-    }
-    Ok(())
-}
-
-async fn ensure_file_exists(path: &PathBuf, label: &str) -> Result<()> {
+async fn ensure_file_exists(path: &Path, label: &str) -> Result<()> {
     let metadata = tokio::fs::metadata(path)
         .await
         .with_context(|| format!("{label} does not exist: {}", path.display()))?;

--- a/kimi-agent/src/config.rs
+++ b/kimi-agent/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use kaos::SshKaosOptions;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
@@ -140,6 +141,26 @@ pub struct MCPConfig {
     pub client: MCPClientConfig,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum KaosConfig {
+    #[default]
+    Local,
+    Ssh {
+        #[serde(flatten)]
+        options: SshKaosOptions,
+    },
+}
+
+impl KaosConfig {
+    pub fn ssh_options(&self) -> Option<SshKaosOptions> {
+        match self {
+            Self::Local => None,
+            Self::Ssh { options } => Some(options.clone()),
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Config {
     #[serde(skip)]
@@ -158,6 +179,8 @@ pub struct Config {
     pub services: Services,
     #[serde(default)]
     pub mcp: MCPConfig,
+    #[serde(default)]
+    pub kaos: KaosConfig,
 }
 
 impl Config {
@@ -177,6 +200,11 @@ impl Config {
                 )));
             }
         }
+        if let KaosConfig::Ssh { options } = &self.kaos
+            && options.host.trim().is_empty()
+        {
+            return Err(ConfigError::new("kaos.ssh host cannot be empty"));
+        }
         Ok(())
     }
 }
@@ -195,6 +223,7 @@ pub fn get_default_config() -> Config {
         loop_control: LoopControl::default(),
         services: Services::default(),
         mcp: MCPConfig::default(),
+        kaos: KaosConfig::default(),
     }
 }
 

--- a/kimi-agent/src/metadata.rs
+++ b/kimi-agent/src/metadata.rs
@@ -49,7 +49,7 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn get_work_dir_meta(&self, path: &KaosPath) -> Option<WorkDirMeta> {
-        let kaos_name = get_current_kaos().name().to_string();
+        let kaos_name = get_current_kaos().storage_name();
         self.work_dirs
             .iter()
             .find(|wd| wd.path == path.to_string() && wd.kaos == kaos_name)
@@ -59,7 +59,7 @@ impl Metadata {
     pub fn new_work_dir_meta(&mut self, path: &KaosPath) -> WorkDirMeta {
         let meta = WorkDirMeta {
             path: path.to_string(),
-            kaos: get_current_kaos().name().to_string(),
+            kaos: get_current_kaos().storage_name(),
             last_session_id: None,
         };
         self.work_dirs.push(meta.clone());
@@ -114,5 +114,5 @@ pub async fn save_metadata(metadata: &Metadata) {
 }
 
 fn default_kaos_name() -> String {
-    LocalKaos::new().name().to_string()
+    LocalKaos::new().storage_name()
 }

--- a/kimi-agent/src/tools/file/grep.rs
+++ b/kimi-agent/src/tools/file/grep.rs
@@ -285,6 +285,21 @@ impl CallableTool2 for Grep {
                 );
             }
         };
+        if let Some(overflow) = process.output_overflow_summary() {
+            return tool_error(
+                "",
+                format!(
+                    "Failed to grep. Process output overflowed and may be incomplete (dropped {} chunks / {} bytes; stdout: {} chunks / {} bytes, stderr: {} chunks / {} bytes).",
+                    overflow.total_dropped_chunks(),
+                    overflow.total_dropped_bytes(),
+                    overflow.stdout_dropped_chunks,
+                    overflow.stdout_dropped_bytes,
+                    overflow.stderr_dropped_chunks,
+                    overflow.stderr_dropped_bytes,
+                ),
+                "Failed to grep",
+            );
+        }
 
         if exitcode != 0 && exitcode != 1 {
             let stderr = String::from_utf8_lossy(&stderr_bytes);

--- a/kimi-agent/src/tools/file/mod.rs
+++ b/kimi-agent/src/tools/file/mod.rs
@@ -502,7 +502,7 @@ pub(super) fn resolve_tool_path(path: &KaosPath, work_dir: &KaosPath) -> KaosPat
     if path.is_absolute() {
         path.canonical()
     } else {
-        KaosPath::from(work_dir.as_path().join(path.as_path())).canonical()
+        work_dir.joinpath(&path.to_string_lossy()).canonical()
     }
 }
 

--- a/kimi-agent/src/tools/shell.rs
+++ b/kimi-agent/src/tools/shell.rs
@@ -215,6 +215,17 @@ impl CallableTool2 for Shell {
                     Ok(code) => code,
                     Err(err) => return tool_runtime_error(&err.to_string()),
                 };
+                if let Some(overflow) = process.output_overflow_summary() {
+                    return tool_runtime_error(&format!(
+                        "Command output overflowed process buffers and is not trustworthy (dropped {} chunks / {} bytes; stdout: {} chunks / {} bytes, stderr: {} chunks / {} bytes).",
+                        overflow.total_dropped_chunks(),
+                        overflow.total_dropped_bytes(),
+                        overflow.stdout_dropped_chunks,
+                        overflow.stdout_dropped_bytes,
+                        overflow.stderr_dropped_chunks,
+                        overflow.stderr_dropped_bytes,
+                    ));
+                }
                 if exitcode == 0 {
                     builder.ok("Command executed successfully.", "")
                 } else {

--- a/kimi-agent/src/utils/environment.rs
+++ b/kimi-agent/src/utils/environment.rs
@@ -1,4 +1,4 @@
-use kaos::KaosPath;
+use kaos::{KaosPath, get_current_kaos};
 
 #[derive(Clone, Debug)]
 pub struct Environment {
@@ -11,7 +11,8 @@ pub struct Environment {
 
 impl Environment {
     pub async fn detect() -> Self {
-        let os_kind = match std::env::consts::OS {
+        let platform = kaos::platform();
+        let os_kind = match platform.os.as_str() {
             "macos" => "macOS",
             "windows" => "Windows",
             "linux" => "Linux",
@@ -19,8 +20,12 @@ impl Environment {
         }
         .to_string();
 
-        let os_arch = std::env::consts::ARCH.to_string();
-        let os_version = sysinfo::System::long_os_version().unwrap_or_default();
+        let os_arch = platform.arch;
+        let os_version = if get_current_kaos().name() == "local" {
+            sysinfo::System::long_os_version().unwrap_or_default()
+        } else {
+            String::new()
+        };
 
         if os_kind == "Windows" {
             return Environment {
@@ -28,14 +33,14 @@ impl Environment {
                 os_arch,
                 os_version,
                 shell_name: "Windows PowerShell".to_string(),
-                shell_path: KaosPath::from("powershell.exe".into()),
+                shell_path: KaosPath::new("powershell.exe"),
             };
         }
 
         let mut shell_name = "sh".to_string();
-        let mut shell_path = KaosPath::from("/bin/sh".into());
+        let mut shell_path = KaosPath::new("/bin/sh");
         for candidate in ["/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"] {
-            let path = KaosPath::from(candidate.into());
+            let path = KaosPath::new(candidate);
             if path.is_file(true).await {
                 shell_name = "bash".to_string();
                 shell_path = path;

--- a/kimi-agent/src/utils/path.rs
+++ b/kimi-agent/src/utils/path.rs
@@ -87,11 +87,7 @@ pub fn shorten_home(path: &KaosPath) -> KaosPath {
 }
 
 pub fn is_within_directory(path: &KaosPath, directory: &KaosPath) -> bool {
-    let path_str = path.to_string_lossy();
-    let dir_str = directory.to_string_lossy();
-    Path::new(&path_str)
-        .strip_prefix(Path::new(&dir_str))
-        .is_ok()
+    path.relative_to(directory).is_ok()
 }
 
 fn parse_rotation_suffix(name: &str, base_name: &str, suffix: &str) -> Option<u64> {

--- a/kimi-agent/tests/config.rs
+++ b/kimi-agent/tests/config.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use kimi_agent::config::{
-    Config, LoopControl, MCPConfig, Services, get_default_config, load_config_from_string,
+    Config, KaosConfig, LoopControl, MCPConfig, Services, get_default_config,
+    load_config_from_string,
 };
 
 #[test]
@@ -16,6 +17,7 @@ fn test_default_config() {
         loop_control: LoopControl::default(),
         services: Services::default(),
         mcp: MCPConfig::default(),
+        kaos: KaosConfig::default(),
     };
     assert_eq!(config, expected);
 }
@@ -43,6 +45,9 @@ fn test_default_config_dump() {
                 "client": {
                     "tool_call_timeout_ms": 60000,
                 },
+            },
+            "kaos": {
+                "type": "local",
             },
         })
     );
@@ -85,4 +90,28 @@ fn test_load_config_reserved_context_size_too_low() {
     let err = load_config_from_string("{\"loop_control\": {\"reserved_context_size\": 500}}")
         .expect_err("reserved_context_size too low");
     assert!(err.to_string().contains("reserved_context_size"));
+}
+
+#[test]
+fn test_load_config_with_ssh_kaos() {
+    let config = load_config_from_string(
+        r#"{
+            "kaos": {
+                "type": "ssh",
+                "host": "example.com",
+                "port": 2222,
+                "username": "alice"
+            }
+        }"#,
+    )
+    .expect("load config");
+
+    match config.kaos {
+        KaosConfig::Local => panic!("expected ssh kaos"),
+        KaosConfig::Ssh { options } => {
+            assert_eq!(options.host, "example.com");
+            assert_eq!(options.port, 2222);
+            assert_eq!(options.username.as_deref(), Some("alice"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This PR introduces a first-class SSH backend for `kaos` and wires it into `kimi-agent` runtime/config paths.

It also hardens several correctness and reliability edges discovered during review, especially around path semantics, stream handling, glob behavior, platform detection, and process lifecycle guarantees.

## What Changed

### 1) New SSH Kaos backend

- Added `kaos/src/ssh.rs` with remote filesystem + process operations.
- Added CLI/config wiring so `kimi-agent` can initialize and use SSH kaos paths.
- Added metadata/config support for SSH kaos selection and session identity.

### 2) Shared line streaming primitive

- Added `kaos/src/line_stream.rs`.
- Refactored local/ssh line-oriented reading to share the same line-stream behavior.
- This keeps behavior aligned between local and remote paths and reduces duplicated parsing logic.

### 3) SSH glob semantics + traversal performance

- Normalized `./`-prefixed patterns (for example `./*.rs`) so they match the same way as local usage.
- Added recursion planning so non-recursive patterns do not force full-tree SFTP traversal.
- Kept a defensive filter for `.` and `..` entries during traversal.

### 4) Process IO robustness under backpressure

- The SSH process reader now uses non-blocking channel writes (`try_send`) instead of blocking sends.
- This prevents `wait()` from hanging when callers do not consume stdout/stderr fast enough.
- Exit propagation no longer depends on output consumers keeping up.

### 5) Platform detection behavior

- Removed silent fallback to `linux/x86_64` on probe failure.
- Platform probing now fails fast and returns explicit errors.
- Current SSH backend behavior is intentionally POSIX-focused and does not attempt Windows remote support.

### 6) KaosPath correctness for non-UTF8 local paths

- `KaosPath` now preserves raw local path bytes when created from local `PathBuf`.
- `unsafe_to_local_path` reconstructs from raw bytes when available.
- Logical identity stays stable: `Eq/Hash` are based on logical path representation, not cache-only byte fields.

### 7) Semantics alignment fixes

- `read_text` over SSH now uses strict UTF-8 decoding (no lossy fallback), matching local behavior.
- Fixed `mkdir(parents=true, exist_ok=false)` behavior so the final target honors `exist_ok`.
- Stabilized SSH storage naming by canonicalizing host case in identity derivation.

### 8) Cross-platform host/remote path handling

- Updated environment shell-path probing to avoid host-OS `PathBuf` conversion for remote POSIX probe paths.
- Prevents Windows host path semantics from corrupting remote Unix probe paths.

## Files Touched (high level)

- `kaos/src/ssh.rs` (new)
- `kaos/src/line_stream.rs` (new)
- `kaos/src/path.rs`
- `kaos/src/local.rs`
- `kaos/src/lib.rs`
- `kaos/Cargo.toml`
- `kimi-agent/src/cli/mod.rs`
- `kimi-agent/src/config.rs`
- `kimi-agent/src/app.rs`
- `kimi-agent/src/metadata.rs`
- `kimi-agent/src/utils/environment.rs`
- `kimi-agent/src/utils/path.rs`
- `kimi-agent/src/tools/file/mod.rs`
- `kimi-agent/tests/config.rs`

## Notes On Non-Obvious Decisions

### A) Why non-blocking output forwarding in SSH process reader

If channel writes block, the reader task can stop before receiving exit events, and `wait()` can stall indefinitely.
Using `try_send` ensures lifecycle events keep flowing.
Under sustained backpressure, output chunks may be dropped, but process completion semantics remain correct and deterministic.

### B) Why fail-fast platform probing

Defaulting probe failures to `linux/x86_64` creates misleading downstream behavior (for example wrong binary target selection).
Explicit failure is safer and easier to debug.

### C) Why KaosPath stores local raw bytes but excludes them from Eq/Hash

Raw-byte caching is required for lossless local round-trip of non-UTF8 filesystem paths.
But logical path identity must not depend on whether a path was constructed from bytes or from string-based joins.
So bytes are retained for conversion only, not for identity semantics.

## Validation

Pre-commit checks passed during commit:

- `cargo fmt`
- `cargo clippy --workspace --all-targets`
- `cargo machete`
