### PR TITLE
feat(wire): add websocket wire transport and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ version number must not diverge from the corresponding Python release.
 
 - Three crates: `kimi-agent`, `kosong`, `kaos`.
 - Rust edition 2024, async runtime `tokio`, serde, anyhow/thiserror, clap, reqwest.
-- Only WireOverStdio UI; no Shell/Print/ACP UI.
+- Only Wire transports (stdio/WebSocket); no Shell/Print/ACP UI.
 - Full parity with Python for data formats and wire behavior.
 - Tests are ported for core runtime/tools/wire; UI-only tests are omitted.
 
@@ -77,7 +77,7 @@ version number must not diverge from the corresponding Python release.
 - `kimi-agent/src/cli/` - CLI parsing and subcommands (`info`, `mcp`).
 - `kimi-agent/src/app.rs` - `KimiCLI::create` and runtime wiring.
 - `kimi-agent/src/soul/` - core agent loop, approvals, compaction, context, toolset.
-- `kimi-agent/src/wire/` - wire types, serde, WireOverStdio JSON-RPC server.
+- `kimi-agent/src/wire/` - wire types, serde, JSON-RPC wire servers (stdio/WebSocket).
 - `kimi-agent/src/tools/` - built-in tools (shell/file/web/todo/multiagent/dmail/think).
 - `kimi-agent/src/skill/` - skills + flow parsing (mermaid/d2).
 - `kimi-agent/src/config.rs`, `metadata.rs`, `session.rs`, `share.rs` - persistence.
@@ -85,7 +85,7 @@ version number must not diverge from the corresponding Python release.
 
 ## Wire protocol and data compatibility
 
-- Wire protocol version `1.1` with JSON-RPC over stdio.
+- Wire protocol version `1.2` with JSON-RPC payload compatibility across stdio/WebSocket transports.
 - Data layout under `~/.kimi` must match Python:
   - `config.toml`, `kimi.json`, session directories, context JSONL, wire JSONL.
 - `Message.content` string/parts serde rules must match Python exactly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -253,8 +254,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2139,6 +2142,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
+ "axum",
  "base64",
  "chrono",
  "clap",
@@ -2167,6 +2171,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "tracing",
@@ -4621,6 +4626,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,6 +4810,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typed-path"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kimi Agent (Rust)
 
-Rust implementation of [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli). Wire-only JSON-RPC agent server over stdio.
+Rust implementation of [Kimi Code CLI](https://github.com/MoonshotAI/kimi-cli). Wire-only JSON-RPC agent server with stdio (default) and WebSocket transports.
 
 ## Build & Run
 

--- a/kimi-agent/Cargo.toml
+++ b/kimi-agent/Cargo.toml
@@ -49,6 +49,7 @@ tempfile = "3"
 
 kaos = { path = "../kaos" }
 kosong = { path = "../kosong" }
+axum = { version = "0.8", features = ["ws"] }
 
 [dev-dependencies]
 serde_json.workspace = true
@@ -56,3 +57,4 @@ tokio.workspace = true
 wiremock = "0.6"
 filetime = "0.2"
 rmcp = { workspace = true, features = ["transport-streamable-http-server"] }
+tokio-tungstenite = "0.28"

--- a/kimi-agent/src/app.rs
+++ b/kimi-agent/src/app.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -18,7 +19,7 @@ use crate::soul::context::Context;
 use crate::soul::kimisoul::KimiSoul;
 use crate::soul::run_soul;
 use crate::wire::WireMessage;
-use crate::wire::server::WireServer;
+use crate::wire::server::{WireServer, WireWsServer};
 
 pub struct KimiCLI {
     soul: Arc<KimiSoul>,
@@ -214,7 +215,12 @@ impl KimiCLI {
     }
 
     pub async fn run_wire_stdio(&self) -> anyhow::Result<()> {
-        let mut server = WireServer::new(Arc::clone(&self.soul));
+        let server = WireServer::new(Arc::clone(&self.soul));
+        server.serve().await
+    }
+
+    pub async fn run_wire_ws(&self, listen_addr: SocketAddr, path: &str) -> anyhow::Result<()> {
+        let server = WireWsServer::new(Arc::clone(&self.soul), listen_addr, path)?;
         server.serve().await
     }
 }

--- a/kimi-agent/src/cli/mod.rs
+++ b/kimi-agent/src/cli/mod.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -106,6 +107,30 @@ pub struct Cli {
     wire: bool,
 
     #[arg(
+        long = "wire-transport",
+        value_enum,
+        default_value = "stdio",
+        help = "Wire transport to use. Default: stdio."
+    )]
+    wire_transport: WireTransport,
+
+    #[arg(
+        long = "wire-listen",
+        value_name = "ADDR",
+        default_value = "127.0.0.1:8765",
+        help = "Listen address for websocket wire transport. Used only when --wire-transport ws."
+    )]
+    wire_listen: String,
+
+    #[arg(
+        long = "wire-path",
+        value_name = "PATH",
+        default_value = "/wire",
+        help = "HTTP path for websocket wire transport. Used only when --wire-transport ws."
+    )]
+    wire_path: String,
+
+    #[arg(
         long = "agent",
         value_enum,
         help = "Builtin agent specification to use. Default: builtin default agent."
@@ -166,6 +191,12 @@ pub struct Cli {
 enum AgentKind {
     Default,
     Okabe,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum WireTransport {
+    Stdio,
+    Ws,
 }
 
 #[derive(Subcommand, Debug)]
@@ -255,7 +286,13 @@ pub async fn run() -> Result<()> {
     .await?;
 
     let session = instance.session().clone();
-    instance.run_wire_stdio().await?;
+    match cli.wire_transport {
+        WireTransport::Stdio => instance.run_wire_stdio().await?,
+        WireTransport::Ws => {
+            let listen_addr = parse_wire_listen_addr(&cli.wire_listen)?;
+            instance.run_wire_ws(listen_addr, &cli.wire_path).await?;
+        }
+    }
     post_run(&session).await?;
     Ok(())
 }
@@ -388,6 +425,11 @@ async fn validate_cli_args(cli: &Cli) -> Result<()> {
         anyhow::bail!("max-ralph-iterations must be >= -1.");
     }
 
+    if matches!(cli.wire_transport, WireTransport::Ws) {
+        parse_wire_listen_addr(&cli.wire_listen)?;
+        validate_wire_path(&cli.wire_path)?;
+    }
+
     Ok(())
 }
 
@@ -426,6 +468,25 @@ fn resolve_thinking(thinking: bool, no_thinking: bool) -> Result<Option<bool>> {
     } else {
         Ok(None)
     }
+}
+
+fn parse_wire_listen_addr(addr: &str) -> Result<SocketAddr> {
+    addr.parse()
+        .with_context(|| format!("Invalid --wire-listen address: {addr}"))
+}
+
+fn validate_wire_path(path: &str) -> Result<()> {
+    let path = path.trim();
+    if path.is_empty() {
+        anyhow::bail!("--wire-path cannot be empty.");
+    }
+    if !path.starts_with('/') {
+        anyhow::bail!("--wire-path must start with '/'.");
+    }
+    if path.contains('?') || path.contains('#') {
+        anyhow::bail!("--wire-path cannot contain query or fragment.");
+    }
+    Ok(())
 }
 
 async fn resolve_session(

--- a/kimi-agent/src/wire/AGENTS.md
+++ b/kimi-agent/src/wire/AGENTS.md
@@ -7,7 +7,7 @@
 - `file.rs`: `WireFile` JSONL persistence, metadata header, `WireMessageRecord`.
 - `protocol.rs`: wire protocol version constants.
 - `jsonrpc.rs`: JSON-RPC models/utilities for wire server.
-- `server.rs`: stdio JSON-RPC wire server.
+- `server.rs`: JSON-RPC wire servers for stdio and WebSocket transports.
 - `channel.rs`: `Wire`, `WireSoulSide`, `WireUISide`, merge + recording logic.
 
 ## Compatibility Rules

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -642,13 +642,21 @@ impl WireWsServer {
     }
 
     pub async fn serve(&self) -> anyhow::Result<()> {
+        let listener = tokio::net::TcpListener::bind(self.listen_addr).await?;
+        self.serve_with_listener(listener).await
+    }
+
+    pub async fn serve_with_listener(
+        &self,
+        listener: tokio::net::TcpListener,
+    ) -> anyhow::Result<()> {
+        let bound_addr = listener.local_addr()?;
         info!(
-            address = %self.listen_addr,
+            address = %bound_addr,
             path = %self.path,
             "Starting Wire server on websocket"
         );
 
-        let listener = tokio::net::TcpListener::bind(self.listen_addr).await?;
         let state = Arc::new(WsServerState::new(self.rpc.clone()));
         let app = Router::new()
             .route(&self.path, get(ws_upgrade_handler))
@@ -687,7 +695,11 @@ async fn ws_upgrade_handler(
     State(state): State<Arc<WsServerState>>,
     ws: WebSocketUpgrade,
 ) -> Response {
-    if state.active_client.swap(true, Ordering::SeqCst) {
+    if state
+        .active_client
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
         return (
             StatusCode::CONFLICT,
             "Only one websocket client is allowed for this wire server.",
@@ -695,8 +707,16 @@ async fn ws_upgrade_handler(
             .into_response();
     }
 
-    ws.on_upgrade(move |socket| async move {
-        handle_ws_socket(socket, Arc::clone(&state)).await;
+    let state_for_upgrade = Arc::clone(&state);
+    let state_for_failed_upgrade = Arc::clone(&state);
+    ws.on_failed_upgrade(move |err| {
+        warn!("Wire websocket upgrade failed: {}", err);
+        state_for_failed_upgrade
+            .active_client
+            .store(false, Ordering::SeqCst);
+    })
+    .on_upgrade(move |socket| async move {
+        handle_ws_socket(socket, state_for_upgrade).await;
     })
     .into_response()
 }

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -776,10 +776,10 @@ async fn handle_ws_socket(socket: WebSocket, state: Arc<WsServerState>) {
         }
     }
 
+    // Stop accepting new connections before tearing down RPC state.
+    state.shutdown.notify_waiters();
     state.rpc.shutdown().await;
     let _ = write_task.await;
-    state.active_client.store(false, Ordering::SeqCst);
-    state.shutdown.notify_waiters();
 }
 
 fn normalize_ws_path(path: &str) -> anyhow::Result<String> {

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -1,8 +1,17 @@
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
+use axum::extract::State;
+use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Router, http::StatusCode};
+use futures::{SinkExt, StreamExt};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -13,16 +22,15 @@ use crate::constant::{NAME, VERSION};
 use crate::soul::kimisoul::KimiSoul;
 use crate::soul::{LLMNotSet, LLMNotSupported, MaxStepsReached, RunCancelled, Soul, run_soul};
 use crate::utils::{Queue, QueueShutDown};
-use crate::wire::{
-    ApprovalRequest, ApprovalResponse, ToolCallRequest, ToolResult, Wire, WireMessage,
-};
-
 use crate::wire::jsonrpc::{
     InitializeParams, JsonRpcErrorObject, JsonRpcErrorResponse, JsonRpcErrorResponseNullableId,
     JsonRpcMessage, JsonRpcSuccessResponse, PromptParams, build_event_message,
     build_request_message, error_codes, statuses,
 };
 use crate::wire::protocol::WIRE_PROTOCOL_VERSION;
+use crate::wire::{
+    ApprovalRequest, ApprovalResponse, ToolCallRequest, ToolResult, Wire, WireMessage,
+};
 
 const STDIO_BUFFER_LIMIT: usize = 100 * 1024 * 1024;
 
@@ -31,17 +39,16 @@ enum PendingRequest {
     ToolCall(ToolCallRequest),
 }
 
-pub struct WireServer {
+#[derive(Clone)]
+struct WireRpcState {
     soul: Arc<KimiSoul>,
     write_queue: Queue<Value>,
     pending: Arc<tokio::sync::Mutex<HashMap<String, PendingRequest>>>,
     cancel_token: Arc<tokio::sync::Mutex<Option<CancellationToken>>>,
 }
 
-pub type WireOverStdio = WireServer;
-
-impl WireServer {
-    pub fn new(soul: Arc<KimiSoul>) -> Self {
+impl WireRpcState {
+    fn new(soul: Arc<KimiSoul>) -> Self {
         Self {
             soul,
             write_queue: Queue::new(),
@@ -50,144 +57,101 @@ impl WireServer {
         }
     }
 
-    pub async fn serve(&mut self) -> anyhow::Result<()> {
-        info!("Starting Wire server on stdio");
-        let stdin = tokio::io::stdin();
-        let stdout = tokio::io::stdout();
-        let mut reader = BufReader::with_capacity(STDIO_BUFFER_LIMIT, stdin);
-        let mut writer = stdout;
+    fn write_queue(&self) -> Queue<Value> {
+        self.write_queue.clone()
+    }
 
-        let write_queue = self.write_queue.clone();
-        let write_task = tokio::spawn(async move {
-            loop {
-                let msg = match write_queue.get().await {
-                    Ok(msg) => msg,
-                    Err(_) => {
-                        debug!("Send queue shut down, stopping Wire server write loop");
-                        break;
-                    }
-                };
-                let line = match serde_json::to_string(&msg) {
-                    Ok(line) => line,
-                    Err(err) => {
-                        error!("Wire server write loop error: {:?}", err);
-                        continue;
-                    }
-                };
-                if let Err(err) = writer.write_all(line.as_bytes()).await {
-                    error!("Wire server write loop error: {:?}", err);
-                    break;
-                }
-                if let Err(err) = writer.write_all(b"\n").await {
-                    error!("Wire server write loop error: {:?}", err);
-                    break;
-                }
-                let _ = writer.flush().await;
-            }
-        });
+    async fn handle_json_line(&self, line: &str) {
+        let line = line.trim();
+        if line.is_empty() {
+            return;
+        }
 
-        let mut buf = Vec::new();
-        loop {
-            buf.clear();
-            let n = reader.read_until(b'\n', &mut buf).await?;
-            if n == 0 {
-                info!("stdin closed, Wire server exiting");
-                break;
-            }
-            let line = String::from_utf8_lossy(&buf);
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            let msg_json: Value = match serde_json::from_str(line) {
-                Ok(value) => value,
-                Err(_) => {
-                    error!("Invalid JSON line: {}", line);
-                    self.send_error_nullable(error_codes::PARSE_ERROR, "Invalid JSON format", None)
-                        .await;
-                    continue;
-                }
-            };
-            let response_hint = msg_json.get("method").is_none() && msg_json.get("id").is_some();
-            let msg: JsonRpcMessage = match serde_json::from_value(msg_json.clone()) {
-                Ok(msg) => msg,
-                Err(err) => {
-                    if response_hint {
-                        error!("Invalid JSON-RPC response: {:?}", err);
-                    } else {
-                        error!("Invalid JSON-RPC message: {:?}", err);
-                    }
-                    let (code, message) = if response_hint {
-                        (error_codes::INVALID_REQUEST, "Invalid response")
-                    } else {
-                        (error_codes::INVALID_REQUEST, "Invalid request")
-                    };
-                    self.send_error_nullable(code, message, None).await;
-                    continue;
-                }
-            };
-
-            if let Some(version) = &msg.jsonrpc
-                && version != "2.0"
-            {
-                self.send_error_nullable(error_codes::INVALID_REQUEST, "Invalid request", None)
+        let msg_json: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(_) => {
+                error!("Invalid JSON line: {}", line);
+                self.send_error_nullable(error_codes::PARSE_ERROR, "Invalid JSON format", None)
                     .await;
-                continue;
+                return;
             }
+        };
 
-            if msg.is_response() {
-                if msg.result.is_none() && msg.error.is_none() {
-                    self.send_error_nullable(
-                        error_codes::INVALID_REQUEST,
-                        "Invalid response",
-                        None,
+        self.handle_json_value(msg_json).await;
+    }
+
+    async fn handle_json_value(&self, msg_json: Value) {
+        let response_hint = msg_json.get("method").is_none() && msg_json.get("id").is_some();
+        let msg: JsonRpcMessage = match serde_json::from_value(msg_json.clone()) {
+            Ok(msg) => msg,
+            Err(err) => {
+                if response_hint {
+                    error!("Invalid JSON-RPC response: {:?}", err);
+                } else {
+                    error!("Invalid JSON-RPC message: {:?}", err);
+                }
+                let (code, message) = if response_hint {
+                    (error_codes::INVALID_REQUEST, "Invalid response")
+                } else {
+                    (error_codes::INVALID_REQUEST, "Invalid request")
+                };
+                self.send_error_nullable(code, message, None).await;
+                return;
+            }
+        };
+
+        if let Some(version) = &msg.jsonrpc
+            && version != "2.0"
+        {
+            self.send_error_nullable(error_codes::INVALID_REQUEST, "Invalid request", None)
+                .await;
+            return;
+        }
+
+        if msg.is_response() {
+            if msg.result.is_none() && msg.error.is_none() {
+                self.send_error_nullable(error_codes::INVALID_REQUEST, "Invalid response", None)
+                    .await;
+                return;
+            }
+            self.handle_response(&msg).await;
+            return;
+        }
+
+        let method = match msg.method.as_deref() {
+            Some(method) => method.to_string(),
+            None => {
+                error!("Invalid JSON-RPC inbound message: {:?}", msg);
+                if let Some(id) = msg.id.clone() {
+                    self.send_error(
+                        id,
+                        error_codes::METHOD_NOT_FOUND,
+                        "Unexpected method received: None",
                     )
                     .await;
-                    continue;
                 }
-                self.handle_response(&msg).await;
-                continue;
+                return;
             }
+        };
 
-            let method = match msg.method.as_deref() {
-                Some(method) => method.to_string(),
-                None => {
-                    error!("Invalid JSON-RPC inbound message: {:?}", msg);
-                    if let Some(id) = msg.id.clone() {
-                        self.send_error(
-                            id,
-                            error_codes::METHOD_NOT_FOUND,
-                            "Unexpected method received: None",
-                        )
-                        .await;
-                    }
-                    continue;
-                }
-            };
-
-            match method.as_str() {
-                "initialize" => self.handle_initialize(msg).await,
-                "prompt" => self.handle_prompt(msg).await,
-                "cancel" => self.handle_cancel(msg).await,
-                _ => {
-                    if let Some(id) = msg.id.clone() {
-                        self.send_error(
-                            id,
-                            error_codes::METHOD_NOT_FOUND,
-                            format!("Unexpected method received: {method}"),
-                        )
-                        .await;
-                    }
+        match method.as_str() {
+            "initialize" => self.handle_initialize(msg).await,
+            "prompt" => self.handle_prompt(msg).await,
+            "cancel" => self.handle_cancel(msg).await,
+            _ => {
+                if let Some(id) = msg.id.clone() {
+                    self.send_error(
+                        id,
+                        error_codes::METHOD_NOT_FOUND,
+                        format!("Unexpected method received: {method}"),
+                    )
+                    .await;
                 }
             }
         }
-
-        self.shutdown().await;
-        let _ = write_task.await;
-        Ok(())
     }
 
-    async fn handle_initialize(&mut self, msg: JsonRpcMessage) {
+    async fn handle_initialize(&self, msg: JsonRpcMessage) {
         let Some(id) = msg.id.clone() else {
             return;
         };
@@ -270,7 +234,7 @@ impl WireServer {
             .put_nowait(serde_json::to_value(response).unwrap_or(Value::Null));
     }
 
-    async fn handle_prompt(&mut self, msg: JsonRpcMessage) {
+    async fn handle_prompt(&self, msg: JsonRpcMessage) {
         let Some(id) = msg.id.clone() else {
             return;
         };
@@ -421,7 +385,7 @@ impl WireServer {
         });
     }
 
-    async fn handle_cancel(&mut self, msg: JsonRpcMessage) {
+    async fn handle_cancel(&self, msg: JsonRpcMessage) {
         let Some(id) = msg.id.clone() else {
             return;
         };
@@ -446,7 +410,7 @@ impl WireServer {
             .put_nowait(serde_json::to_value(response).unwrap_or(Value::Null));
     }
 
-    async fn handle_response(&mut self, msg: &JsonRpcMessage) {
+    async fn handle_response(&self, msg: &JsonRpcMessage) {
         let Some(id) = msg.id.clone() else {
             return;
         };
@@ -589,6 +553,229 @@ impl WireServer {
     }
 }
 
+pub struct WireServer {
+    rpc: WireRpcState,
+}
+
+pub type WireOverStdio = WireServer;
+
+impl WireServer {
+    pub fn new(soul: Arc<KimiSoul>) -> Self {
+        Self {
+            rpc: WireRpcState::new(soul),
+        }
+    }
+
+    pub async fn serve(&self) -> anyhow::Result<()> {
+        info!("Starting Wire server on stdio");
+        let stdin = tokio::io::stdin();
+        let stdout = tokio::io::stdout();
+        let mut reader = BufReader::with_capacity(STDIO_BUFFER_LIMIT, stdin);
+        let mut writer = stdout;
+
+        let write_queue = self.rpc.write_queue();
+        let write_task = tokio::spawn(async move {
+            loop {
+                let msg = match write_queue.get().await {
+                    Ok(msg) => msg,
+                    Err(_) => {
+                        debug!("Send queue shut down, stopping Wire server write loop");
+                        break;
+                    }
+                };
+                let line = match serde_json::to_string(&msg) {
+                    Ok(line) => line,
+                    Err(err) => {
+                        error!("Wire server write loop error: {:?}", err);
+                        continue;
+                    }
+                };
+                if let Err(err) = writer.write_all(line.as_bytes()).await {
+                    error!("Wire server write loop error: {:?}", err);
+                    break;
+                }
+                if let Err(err) = writer.write_all(b"\n").await {
+                    error!("Wire server write loop error: {:?}", err);
+                    break;
+                }
+                let _ = writer.flush().await;
+            }
+        });
+
+        let mut buf = Vec::new();
+        loop {
+            buf.clear();
+            let n = reader.read_until(b'\n', &mut buf).await?;
+            if n == 0 {
+                info!("stdin closed, Wire server exiting");
+                break;
+            }
+            let line = String::from_utf8_lossy(&buf);
+            self.rpc.handle_json_line(&line).await;
+        }
+
+        self.rpc.shutdown().await;
+        let _ = write_task.await;
+        Ok(())
+    }
+}
+
+pub struct WireWsServer {
+    rpc: WireRpcState,
+    listen_addr: SocketAddr,
+    path: String,
+}
+
+impl WireWsServer {
+    pub fn new(
+        soul: Arc<KimiSoul>,
+        listen_addr: SocketAddr,
+        path: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        let path = path.into();
+        let path = normalize_ws_path(&path)?;
+        Ok(Self {
+            rpc: WireRpcState::new(soul),
+            listen_addr,
+            path,
+        })
+    }
+
+    pub async fn serve(&self) -> anyhow::Result<()> {
+        info!(
+            address = %self.listen_addr,
+            path = %self.path,
+            "Starting Wire server on websocket"
+        );
+
+        let listener = tokio::net::TcpListener::bind(self.listen_addr).await?;
+        let state = Arc::new(WsServerState::new(self.rpc.clone()));
+        let app = Router::new()
+            .route(&self.path, get(ws_upgrade_handler))
+            .with_state(Arc::clone(&state));
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(wait_for_ws_shutdown(Arc::clone(&state)))
+            .await?;
+
+        self.rpc.shutdown().await;
+        Ok(())
+    }
+}
+
+struct WsServerState {
+    rpc: WireRpcState,
+    active_client: AtomicBool,
+    shutdown: Notify,
+}
+
+impl WsServerState {
+    fn new(rpc: WireRpcState) -> Self {
+        Self {
+            rpc,
+            active_client: AtomicBool::new(false),
+            shutdown: Notify::new(),
+        }
+    }
+}
+
+async fn wait_for_ws_shutdown(state: Arc<WsServerState>) {
+    state.shutdown.notified().await;
+}
+
+async fn ws_upgrade_handler(
+    State(state): State<Arc<WsServerState>>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    if state.active_client.swap(true, Ordering::SeqCst) {
+        return (
+            StatusCode::CONFLICT,
+            "Only one websocket client is allowed for this wire server.",
+        )
+            .into_response();
+    }
+
+    ws.on_upgrade(move |socket| async move {
+        handle_ws_socket(socket, Arc::clone(&state)).await;
+    })
+    .into_response()
+}
+
+async fn handle_ws_socket(socket: WebSocket, state: Arc<WsServerState>) {
+    let (mut sender, mut receiver) = socket.split();
+
+    let write_queue = state.rpc.write_queue();
+    let write_task = tokio::spawn(async move {
+        loop {
+            let msg = match write_queue.get().await {
+                Ok(msg) => msg,
+                Err(_) => {
+                    debug!("Send queue shut down, stopping websocket write loop");
+                    break;
+                }
+            };
+
+            let line = match serde_json::to_string(&msg) {
+                Ok(line) => line,
+                Err(err) => {
+                    error!("Wire websocket write loop error: {:?}", err);
+                    continue;
+                }
+            };
+
+            if let Err(err) = sender.send(WsMessage::Text(line.into())).await {
+                error!("Wire websocket write loop error: {:?}", err);
+                break;
+            }
+        }
+    });
+
+    while let Some(frame) = receiver.next().await {
+        match frame {
+            Ok(WsMessage::Text(text)) => {
+                state.rpc.handle_json_line(text.as_str()).await;
+            }
+            Ok(WsMessage::Binary(binary)) => match std::str::from_utf8(binary.as_ref()) {
+                Ok(text) => state.rpc.handle_json_line(text).await,
+                Err(_) => {
+                    state
+                        .rpc
+                        .send_error_nullable(error_codes::INVALID_REQUEST, "Invalid request", None)
+                        .await;
+                }
+            },
+            Ok(WsMessage::Ping(_)) | Ok(WsMessage::Pong(_)) => {}
+            Ok(WsMessage::Close(_)) => {
+                info!("websocket closed by client, Wire server exiting");
+                break;
+            }
+            Err(err) => {
+                error!("Wire websocket read loop error: {:?}", err);
+                break;
+            }
+        }
+    }
+
+    state.rpc.shutdown().await;
+    let _ = write_task.await;
+    state.active_client.store(false, Ordering::SeqCst);
+    state.shutdown.notify_waiters();
+}
+
+fn normalize_ws_path(path: &str) -> anyhow::Result<String> {
+    let normalized = path.trim();
+    if normalized.is_empty() {
+        anyhow::bail!("wire path cannot be empty");
+    }
+    if !normalized.starts_with('/') {
+        anyhow::bail!("wire path must start with '/'");
+    }
+    if normalized.contains('?') || normalized.contains('#') {
+        anyhow::bail!("wire path cannot contain query or fragment");
+    }
+    Ok(normalized.to_string())
+}
+
 async fn stream_wire_messages(
     write_queue: Queue<Value>,
     pending: Arc<tokio::sync::Mutex<HashMap<String, PendingRequest>>>,
@@ -645,4 +832,23 @@ async fn request_tool_call(
     let out = build_request_message(msg_id, WireMessage::ToolCallRequest(request.clone()));
     let _ = write_queue.put_nowait(serde_json::to_value(out).unwrap_or(Value::Null));
     let _ = request.wait().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_ws_path;
+
+    #[test]
+    fn normalize_ws_path_accepts_valid_path() {
+        assert_eq!(normalize_ws_path("/wire").unwrap(), "/wire");
+        assert_eq!(normalize_ws_path(" /api/ws ").unwrap(), "/api/ws");
+    }
+
+    #[test]
+    fn normalize_ws_path_rejects_invalid_path() {
+        assert!(normalize_ws_path("").is_err());
+        assert!(normalize_ws_path("wire").is_err());
+        assert!(normalize_ws_path("/wire?x=1").is_err());
+        assert!(normalize_ws_path("/wire#frag").is_err());
+    }
 }

--- a/kimi-agent/tests/wire_ws.rs
+++ b/kimi-agent/tests/wire_ws.rs
@@ -14,6 +14,7 @@ use kimi_agent::config::{LLMModel, LLMProvider, ProviderType, get_default_config
 use kimi_agent::constant::{NAME, VERSION};
 use kimi_agent::session::Session;
 use kimi_agent::wire::protocol::WIRE_PROTOCOL_VERSION;
+use kimi_agent::wire::server::WireWsServer;
 
 static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
@@ -59,11 +60,6 @@ fn set_home_env(path: &Path) -> Vec<EnvGuard> {
             share_dir.to_str().expect("share dir path"),
         ),
     ]
-}
-
-fn reserve_free_port() -> u16 {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind free port");
-    listener.local_addr().expect("local addr").port()
 }
 
 async fn connect_ws_with_retry(
@@ -176,11 +172,14 @@ async fn test_wire_ws_initialize_and_prompt() {
     let work_dir = TempDir::new().expect("work dir");
     let (cli, _env) = create_scripted_cli(&["text: hello from ws"], &home_dir, &work_dir).await;
 
-    let port = reserve_free_port();
-    let listen_addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-    let server_task = tokio::spawn(async move { cli.run_wire_ws(listen_addr, "/wire").await });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let listen_addr = listener.local_addr().expect("listener local addr");
+    let server = WireWsServer::new(cli.soul(), listen_addr, "/wire").expect("wire ws server");
+    let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
 
-    let mut ws = connect_ws_with_retry(&format!("ws://127.0.0.1:{port}/wire")).await;
+    let mut ws = connect_ws_with_retry(&format!("ws://{listen_addr}/wire")).await;
     ws.send(Message::Text(
         json!({
             "jsonrpc": "2.0",
@@ -285,11 +284,14 @@ async fn test_wire_ws_external_tool_request_roundtrip() {
     )
     .await;
 
-    let port = reserve_free_port();
-    let listen_addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
-    let server_task = tokio::spawn(async move { cli.run_wire_ws(listen_addr, "/wire").await });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let listen_addr = listener.local_addr().expect("listener local addr");
+    let server = WireWsServer::new(cli.soul(), listen_addr, "/wire").expect("wire ws server");
+    let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
 
-    let mut ws = connect_ws_with_retry(&format!("ws://127.0.0.1:{port}/wire")).await;
+    let mut ws = connect_ws_with_retry(&format!("ws://{listen_addr}/wire")).await;
     ws.send(Message::Text(
         json!({
             "jsonrpc": "2.0",

--- a/kimi-agent/tests/wire_ws.rs
+++ b/kimi-agent/tests/wire_ws.rs
@@ -1,0 +1,416 @@
+use std::path::Path;
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+
+use kaos::KaosPath;
+use kimi_agent::app::{ConfigInput, CreateOptions, KimiCLI};
+use kimi_agent::config::{LLMModel, LLMProvider, ProviderType, get_default_config};
+use kimi_agent::constant::{NAME, VERSION};
+use kimi_agent::session::Session;
+use kimi_agent::wire::protocol::WIRE_PROTOCOL_VERSION;
+
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = &self.prev {
+            // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+            unsafe {
+                std::env::set_var(self.key, prev);
+            }
+        } else {
+            // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+            unsafe {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+fn set_home_env(path: &Path) -> Vec<EnvGuard> {
+    let share_dir = path.join(".kimi");
+    vec![
+        EnvGuard::set("HOME", path.to_str().expect("home path")),
+        EnvGuard::set("USERPROFILE", path.to_str().expect("home path")),
+        EnvGuard::set(
+            "KIMI_SHARE_DIR",
+            share_dir.to_str().expect("share dir path"),
+        ),
+    ]
+}
+
+fn reserve_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind free port");
+    listener.local_addr().expect("local addr").port()
+}
+
+async fn connect_ws_with_retry(
+    url: &str,
+) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
+    let mut last_err = String::new();
+    for _ in 0..50 {
+        match connect_async(url).await {
+            Ok((stream, _resp)) => return stream,
+            Err(err) => {
+                last_err = err.to_string();
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+    panic!("failed to connect websocket {url}: {last_err}");
+}
+
+async fn recv_json(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> Value {
+    loop {
+        let frame = tokio::time::timeout(Duration::from_secs(10), ws.next())
+            .await
+            .expect("timed out waiting for ws frame")
+            .expect("ws stream closed")
+            .expect("ws frame error");
+        match frame {
+            Message::Text(text) => {
+                return serde_json::from_str(text.as_str()).expect("valid json text frame");
+            }
+            Message::Binary(bin) => {
+                return serde_json::from_slice(&bin).expect("valid json binary frame");
+            }
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+            Message::Close(close) => panic!("unexpected ws close frame: {close:?}"),
+        }
+    }
+}
+
+async fn create_scripted_cli(
+    scripts: &[&str],
+    home_dir: &TempDir,
+    work_dir: &TempDir,
+) -> (KimiCLI, Vec<EnvGuard>) {
+    let mut env = set_home_env(home_dir.path());
+    let scripts_path = home_dir.path().join("scripts.json");
+    let scripts_json: Vec<String> = scripts.iter().map(|script| script.to_string()).collect();
+    std::fs::write(
+        &scripts_path,
+        serde_json::to_string(&scripts_json).expect("serialize scripts"),
+    )
+    .expect("write scripted echo file");
+    env.push(EnvGuard::set(
+        "KIMI_SCRIPTED_ECHO_SCRIPTS",
+        scripts_path.to_str().expect("scripts path"),
+    ));
+
+    let mut config = get_default_config();
+    config.default_model = "scripted".to_string();
+    config.models.insert(
+        "scripted".to_string(),
+        LLMModel {
+            provider: "scripted_provider".to_string(),
+            model: "scripted_echo".to_string(),
+            max_context_size: 100_000,
+            capabilities: None,
+        },
+    );
+    config.providers.insert(
+        "scripted_provider".to_string(),
+        LLMProvider {
+            provider_type: ProviderType::ScriptedEcho,
+            base_url: String::new(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        },
+    );
+
+    let work_path = KaosPath::from(work_dir.path().to_path_buf());
+    let session = Session::create(work_path, None, None).await;
+    let cli = KimiCLI::create(
+        session,
+        CreateOptions {
+            config: Some(ConfigInput::Inline(Box::new(config))),
+            model_name: None,
+            thinking: Some(false),
+            yolo: true,
+            agent_file: None,
+            mcp_configs: vec![],
+            skills_dir: None,
+            max_steps_per_turn: None,
+            max_retries_per_step: None,
+            max_ralph_iterations: None,
+        },
+    )
+    .await
+    .expect("create kimi cli");
+
+    (cli, env)
+}
+
+#[tokio::test]
+async fn test_wire_ws_initialize_and_prompt() {
+    let _lock = ENV_LOCK.lock().await;
+    let home_dir = TempDir::new().expect("home dir");
+    let work_dir = TempDir::new().expect("work dir");
+    let (cli, _env) = create_scripted_cli(&["text: hello from ws"], &home_dir, &work_dir).await;
+
+    let port = reserve_free_port();
+    let listen_addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
+    let server_task = tokio::spawn(async move { cli.run_wire_ws(listen_addr, "/wire").await });
+
+    let mut ws = connect_ws_with_retry(&format!("ws://127.0.0.1:{port}/wire")).await;
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": { "protocol_version": WIRE_PROTOCOL_VERSION }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send initialize");
+
+    let init_resp = recv_json(&mut ws).await;
+    assert_eq!(
+        init_resp.get("id"),
+        Some(&Value::String("init".to_string()))
+    );
+    assert_eq!(
+        init_resp
+            .get("result")
+            .and_then(|v| v.get("protocol_version"))
+            .and_then(Value::as_str),
+        Some(WIRE_PROTOCOL_VERSION)
+    );
+    assert_eq!(
+        init_resp
+            .get("result")
+            .and_then(|v| v.get("server"))
+            .and_then(|v| v.get("name"))
+            .and_then(Value::as_str),
+        Some(NAME)
+    );
+    assert_eq!(
+        init_resp
+            .get("result")
+            .and_then(|v| v.get("server"))
+            .and_then(|v| v.get("version"))
+            .and_then(Value::as_str),
+        Some(VERSION)
+    );
+
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "prompt-1",
+            "method": "prompt",
+            "params": { "user_input": "hello" }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send prompt");
+
+    let mut saw_event = false;
+    let mut prompt_resp: Option<Value> = None;
+    for _ in 0..200 {
+        let msg = recv_json(&mut ws).await;
+        if msg.get("method").and_then(Value::as_str) == Some("event") {
+            saw_event = true;
+        }
+        if msg.get("id").and_then(Value::as_str) == Some("prompt-1") {
+            prompt_resp = Some(msg);
+            break;
+        }
+    }
+
+    assert!(saw_event, "expected at least one event message");
+    let prompt_resp = prompt_resp.expect("prompt response");
+    assert_eq!(
+        prompt_resp
+            .get("result")
+            .and_then(|v| v.get("status"))
+            .and_then(Value::as_str),
+        Some("finished")
+    );
+
+    ws.close(None).await.expect("close ws");
+    let server_result = tokio::time::timeout(Duration::from_secs(10), server_task)
+        .await
+        .expect("server task timeout")
+        .expect("server task join");
+    assert!(
+        server_result.is_ok(),
+        "server returned error: {server_result:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_wire_ws_external_tool_request_roundtrip() {
+    let _lock = ENV_LOCK.lock().await;
+    let home_dir = TempDir::new().expect("home dir");
+    let work_dir = TempDir::new().expect("work dir");
+    let (cli, _env) = create_scripted_cli(
+        &[
+            r#"tool_call: {"id":"tc-1","name":"open_in_ide","arguments":"{\"path\":\"/tmp/a\"}"}"#,
+            "text: tool handled",
+        ],
+        &home_dir,
+        &work_dir,
+    )
+    .await;
+
+    let port = reserve_free_port();
+    let listen_addr: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().expect("addr");
+    let server_task = tokio::spawn(async move { cli.run_wire_ws(listen_addr, "/wire").await });
+
+    let mut ws = connect_ws_with_retry(&format!("ws://127.0.0.1:{port}/wire")).await;
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init",
+            "method": "initialize",
+            "params": {
+                "protocol_version": WIRE_PROTOCOL_VERSION,
+                "external_tools": [
+                    {
+                        "name": "open_in_ide",
+                        "description": "Open file in IDE",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "path": { "type": "string" }
+                            },
+                            "required": ["path"],
+                            "additionalProperties": false
+                        }
+                    }
+                ]
+            }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send initialize");
+
+    let init_resp = recv_json(&mut ws).await;
+    assert_eq!(
+        init_resp.get("id"),
+        Some(&Value::String("init".to_string()))
+    );
+    assert_eq!(
+        init_resp
+            .get("result")
+            .and_then(|v| v.get("external_tools"))
+            .and_then(|v| v.get("accepted"))
+            .and_then(Value::as_array)
+            .map(|items| items.iter().filter_map(Value::as_str).collect::<Vec<_>>()),
+        Some(vec!["open_in_ide"])
+    );
+
+    ws.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "prompt-1",
+            "method": "prompt",
+            "params": { "user_input": "use tool" }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send prompt");
+
+    let mut saw_tool_request = false;
+    let mut prompt_resp: Option<Value> = None;
+    for _ in 0..200 {
+        let msg = recv_json(&mut ws).await;
+        if msg.get("method").and_then(Value::as_str) == Some("request") {
+            let request_id = msg
+                .get("id")
+                .and_then(Value::as_str)
+                .expect("request id")
+                .to_string();
+            let payload = msg
+                .get("params")
+                .and_then(|v| v.get("payload"))
+                .expect("request payload");
+            let tool_call_id = payload
+                .get("id")
+                .and_then(Value::as_str)
+                .expect("tool call id")
+                .to_string();
+            saw_tool_request = true;
+
+            ws.send(Message::Text(
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "tool_call_id": tool_call_id,
+                        "return_value": {
+                            "is_error": false,
+                            "output": "ok",
+                            "message": "ok",
+                            "display": []
+                        }
+                    }
+                })
+                .to_string()
+                .into(),
+            ))
+            .await
+            .expect("send tool result");
+        }
+        if msg.get("id").and_then(Value::as_str) == Some("prompt-1") {
+            prompt_resp = Some(msg);
+            break;
+        }
+    }
+
+    assert!(saw_tool_request, "expected tool call request over wire ws");
+    let prompt_resp = prompt_resp.expect("prompt response");
+    assert_eq!(
+        prompt_resp
+            .get("result")
+            .and_then(|v| v.get("status"))
+            .and_then(Value::as_str),
+        Some("finished")
+    );
+
+    ws.close(None).await.expect("close ws");
+    let server_result = tokio::time::timeout(Duration::from_secs(10), server_task)
+        .await
+        .expect("server task timeout")
+        .expect("server task join");
+    assert!(
+        server_result.is_ok(),
+        "server returned error: {server_result:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- add optional WebSocket wire transport while keeping stdio as default
- refactor wire JSON-RPC handling to share one transport-agnostic RPC core for stdio/ws
- add CLI flags: `--wire-transport`, `--wire-listen`, `--wire-path`
- add integration tests for ws initialize/prompt and request/response roundtrip
- fix ws edge cases: rollback active client slot on failed upgrade and de-race test listener binding

## Validation
- cargo fmt
- cargo clippy --workspace --all-targets
- cargo test -p kimi-agent
- cargo test -p kimi-agent wire_ws -- --nocapture