### PR TITLE
feat(wire): support websocket multi-session runtime

### DIFF
--- a/kimi-agent/src/app.rs
+++ b/kimi-agent/src/app.rs
@@ -19,7 +19,7 @@ use crate::soul::context::Context;
 use crate::soul::kimisoul::KimiSoul;
 use crate::soul::run_soul;
 use crate::wire::WireMessage;
-use crate::wire::server::{WireServer, WireWsServer};
+use crate::wire::server::{WireServer, WireWsServer, WsSessionRuntimeOptions};
 
 pub struct KimiCLI {
     soul: Arc<KimiSoul>,
@@ -219,8 +219,13 @@ impl KimiCLI {
         server.serve().await
     }
 
-    pub async fn run_wire_ws(&self, listen_addr: SocketAddr, path: &str) -> anyhow::Result<()> {
-        let server = WireWsServer::new(Arc::clone(&self.soul), listen_addr, path)?;
+    pub async fn run_wire_ws(
+        &self,
+        options: WsSessionRuntimeOptions,
+        listen_addr: SocketAddr,
+        path: &str,
+    ) -> anyhow::Result<()> {
+        let server = WireWsServer::new(options, listen_addr, path)?;
         server.serve().await
     }
 }

--- a/kimi-agent/src/cli/mod.rs
+++ b/kimi-agent/src/cli/mod.rs
@@ -293,7 +293,7 @@ pub async fn run() -> Result<()> {
         }
         WireTransport::Ws => {
             let listen_addr = parse_wire_listen_addr(&cli.wire_listen)?;
-            let server = crate::wire::server::WireWsServer::new_multi(
+            let server = crate::wire::server::WireWsServer::new(
                 crate::wire::server::WsSessionRuntimeOptions {
                     work_dir,
                     default_session_id: default_session.id.clone(),

--- a/kimi-agent/src/cli/mod.rs
+++ b/kimi-agent/src/cli/mod.rs
@@ -11,6 +11,7 @@ use crate::app::{ConfigInput, CreateOptions, KimiCLI};
 use crate::config::{Config, KaosConfig, load_config, load_config_from_string};
 use crate::constant::VERSION;
 use crate::session::{Session, post_run};
+use crate::session_id::normalize_session_id;
 use crate::utils::init_logging;
 use tracing::info;
 
@@ -262,14 +263,13 @@ pub async fn run() -> Result<()> {
         None => KaosPath::cwd(),
     };
 
-    let default_session =
-        resolve_session(&work_dir, cli.session_id.as_ref(), cli.continue_session).await?;
-
     let agent_file = resolve_agent_file(cli.agent, cli.agent_file.as_ref())?;
     let thinking = resolve_thinking(cli.thinking, cli.no_thinking)?;
 
     match cli.wire_transport {
         WireTransport::Stdio => {
+            let default_session =
+                resolve_session(&work_dir, cli.session_id.as_ref(), cli.continue_session).await?;
             let instance = KimiCLI::create(
                 default_session,
                 CreateOptions {
@@ -293,10 +293,16 @@ pub async fn run() -> Result<()> {
         }
         WireTransport::Ws => {
             let listen_addr = parse_wire_listen_addr(&cli.wire_listen)?;
+            let default_session_id = resolve_ws_default_session_id(
+                &work_dir,
+                cli.session_id.as_ref(),
+                cli.continue_session,
+            )
+            .await?;
             let server = crate::wire::server::WireWsServer::new(
                 crate::wire::server::WsSessionRuntimeOptions {
                     work_dir,
-                    default_session_id: default_session.id.clone(),
+                    default_session_id,
                     config,
                     model_name: cli.model_name.clone(),
                     thinking,
@@ -515,14 +521,15 @@ async fn resolve_session(
     continue_session: bool,
 ) -> Result<Session> {
     if let Some(session_id) = session_id {
-        let trimmed = session_id.trim();
-        let found = Session::find(work_dir.clone(), trimmed).await;
+        let normalized = normalize_session_id(session_id)
+            .map_err(|err| anyhow::anyhow!("Invalid --session value: {err}"))?;
+        let found = Session::find(work_dir.clone(), &normalized).await;
         if let Some(session) = found {
             info!("Switching to session: {}", session.id);
             return Ok(session);
         }
-        info!("Session {} not found, creating new session", trimmed);
-        let session = Session::create(work_dir.clone(), Some(trimmed.to_string()), None).await;
+        info!("Session {} not found, creating new session", normalized);
+        let session = Session::create(work_dir.clone(), Some(normalized), None).await;
         info!("Switching to session: {}", session.id);
         return Ok(session);
     }
@@ -538,4 +545,45 @@ async fn resolve_session(
     let session = Session::create(work_dir.clone(), None, None).await;
     info!("Created new session: {}", session.id);
     Ok(session)
+}
+
+async fn resolve_ws_default_session_id(
+    work_dir: &KaosPath,
+    session_id: Option<&String>,
+    continue_session: bool,
+) -> Result<String> {
+    if let Some(session_id) = session_id {
+        return normalize_session_id(session_id)
+            .map_err(|err| anyhow::anyhow!("Invalid --session value: {err}"));
+    }
+
+    if continue_session {
+        if let Some(session) = Session::continue_(work_dir.clone()).await {
+            return normalize_session_id(&session.id).map_err(|err| {
+                anyhow::anyhow!("Invalid session ID in previous session metadata: {err}")
+            });
+        }
+        anyhow::bail!("No previous session found for the working directory.");
+    }
+
+    Ok(uuid::Uuid::new_v4().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use kaos::KaosPath;
+
+    use super::resolve_ws_default_session_id;
+
+    #[tokio::test]
+    async fn ws_default_session_id_rejects_invalid_custom_session() {
+        let work_dir = TempDir::new().expect("work dir");
+        let work_path = KaosPath::from(work_dir.path().to_path_buf());
+        let invalid_session = "bad:id".to_string();
+
+        let result = resolve_ws_default_session_id(&work_path, Some(&invalid_session), false).await;
+        assert!(result.is_err());
+    }
 }

--- a/kimi-agent/src/cli/mod.rs
+++ b/kimi-agent/src/cli/mod.rs
@@ -10,10 +10,9 @@ use crate::agentspec::{default_agent_file, okabe_agent_file};
 use crate::app::{ConfigInput, CreateOptions, KimiCLI};
 use crate::config::{Config, KaosConfig, load_config, load_config_from_string};
 use crate::constant::VERSION;
-use crate::metadata::{load_metadata, save_metadata};
-use crate::session::Session;
+use crate::session::{Session, post_run};
 use crate::utils::init_logging;
-use tracing::{info, warn};
+use tracing::info;
 
 pub mod info;
 pub mod mcp;
@@ -263,37 +262,58 @@ pub async fn run() -> Result<()> {
         None => KaosPath::cwd(),
     };
 
-    let session = resolve_session(&work_dir, cli.session_id.as_ref(), cli.continue_session).await?;
+    let default_session =
+        resolve_session(&work_dir, cli.session_id.as_ref(), cli.continue_session).await?;
 
     let agent_file = resolve_agent_file(cli.agent, cli.agent_file.as_ref())?;
     let thinking = resolve_thinking(cli.thinking, cli.no_thinking)?;
 
-    let instance = KimiCLI::create(
-        session,
-        CreateOptions {
-            config: Some(ConfigInput::Inline(Box::new(config))),
-            model_name: cli.model_name.clone(),
-            thinking,
-            yolo: cli.yolo,
-            agent_file,
-            mcp_configs,
-            skills_dir,
-            max_steps_per_turn: cli.max_steps_per_turn,
-            max_retries_per_step: cli.max_retries_per_step,
-            max_ralph_iterations: cli.max_ralph_iterations,
-        },
-    )
-    .await?;
-
-    let session = instance.session().clone();
     match cli.wire_transport {
-        WireTransport::Stdio => instance.run_wire_stdio().await?,
+        WireTransport::Stdio => {
+            let instance = KimiCLI::create(
+                default_session,
+                CreateOptions {
+                    config: Some(ConfigInput::Inline(Box::new(config))),
+                    model_name: cli.model_name.clone(),
+                    thinking,
+                    yolo: cli.yolo,
+                    agent_file,
+                    mcp_configs,
+                    skills_dir,
+                    max_steps_per_turn: cli.max_steps_per_turn,
+                    max_retries_per_step: cli.max_retries_per_step,
+                    max_ralph_iterations: cli.max_ralph_iterations,
+                },
+            )
+            .await?;
+
+            let session = instance.session().clone();
+            instance.run_wire_stdio().await?;
+            post_run(&session).await?;
+        }
         WireTransport::Ws => {
             let listen_addr = parse_wire_listen_addr(&cli.wire_listen)?;
-            instance.run_wire_ws(listen_addr, &cli.wire_path).await?;
+            let server = crate::wire::server::WireWsServer::new_multi(
+                crate::wire::server::WsSessionRuntimeOptions {
+                    work_dir,
+                    default_session_id: default_session.id.clone(),
+                    config,
+                    model_name: cli.model_name.clone(),
+                    thinking,
+                    yolo: cli.yolo,
+                    agent_file,
+                    mcp_configs,
+                    skills_dir,
+                    max_steps_per_turn: cli.max_steps_per_turn,
+                    max_retries_per_step: cli.max_retries_per_step,
+                    max_ralph_iterations: cli.max_ralph_iterations,
+                },
+                listen_addr,
+                &cli.wire_path,
+            )?;
+            server.serve().await?;
         }
     }
-    post_run(&session).await?;
     Ok(())
 }
 
@@ -518,40 +538,4 @@ async fn resolve_session(
     let session = Session::create(work_dir.clone(), None, None).await;
     info!("Created new session: {}", session.id);
     Ok(session)
-}
-
-async fn post_run(session: &Session) -> Result<()> {
-    let mut metadata = load_metadata().await;
-    let mut index = metadata.work_dirs.iter().position(|meta| {
-        meta.path == session.work_dir.to_string() && meta.kaos == session.work_dir_meta.kaos
-    });
-
-    if index.is_none() {
-        warn!(
-            "Work dir metadata missing when marking last session, recreating: {}",
-            session.work_dir.to_string_lossy()
-        );
-        let meta = session.work_dir_meta.clone();
-        metadata.work_dirs.push(meta);
-        index = Some(metadata.work_dirs.len() - 1);
-    }
-
-    let Some(idx) = index else {
-        save_metadata(&metadata).await;
-        return Ok(());
-    };
-
-    let meta = &mut metadata.work_dirs[idx];
-    if session.is_empty().await {
-        info!("Session {} has empty context, removing it", session.id);
-        session.delete().await;
-        if meta.last_session_id.as_deref() == Some(&session.id) {
-            meta.last_session_id = None;
-        }
-    } else {
-        meta.last_session_id = Some(session.id.clone());
-    }
-
-    save_metadata(&metadata).await;
-    Ok(())
 }

--- a/kimi-agent/src/lib.rs
+++ b/kimi-agent/src/lib.rs
@@ -8,6 +8,7 @@ pub mod llm;
 pub mod metadata;
 pub mod prompts;
 pub mod session;
+pub mod session_id;
 pub mod share;
 pub mod skill;
 pub mod soul;

--- a/kimi-agent/src/metadata.rs
+++ b/kimi-agent/src/metadata.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -75,12 +75,16 @@ impl Metadata {
 pub async fn load_metadata() -> Metadata {
     let _ = ensure_share_dir().await;
     let metadata_file = get_metadata_file();
+    load_metadata_from_path(&metadata_file).await
+}
+
+async fn load_metadata_from_path(metadata_file: &Path) -> Metadata {
     debug!("Loading metadata from file: {}", metadata_file.display());
-    if tokio::fs::metadata(&metadata_file).await.is_err() {
+    if tokio::fs::metadata(metadata_file).await.is_err() {
         debug!("No metadata file found, creating empty metadata");
         return Metadata::default();
     }
-    let text = tokio::fs::read_to_string(&metadata_file)
+    let text = tokio::fs::read_to_string(metadata_file)
         .await
         .unwrap_or_else(|err| {
             panic!(
@@ -94,6 +98,10 @@ pub async fn load_metadata() -> Metadata {
 
 pub async fn save_metadata(metadata: &Metadata) {
     let metadata_file = get_metadata_file();
+    save_metadata_to_path(&metadata_file, metadata).await;
+}
+
+async fn save_metadata_to_path(metadata_file: &Path, metadata: &Metadata) {
     debug!("Saving metadata to file: {}", metadata_file.display());
     if let Some(parent) = metadata_file.parent() {
         tokio::fs::create_dir_all(parent)
@@ -122,7 +130,7 @@ pub async fn save_metadata(metadata: &Metadata) {
                 temp_file.display()
             )
         });
-    tokio::fs::rename(&temp_file, &metadata_file)
+    tokio::fs::rename(&temp_file, metadata_file)
         .await
         .unwrap_or_else(|err| {
             panic!(
@@ -134,10 +142,19 @@ pub async fn save_metadata(metadata: &Metadata) {
 }
 
 pub async fn update_metadata<R>(update: impl FnOnce(&mut Metadata) -> R) -> R {
+    let _ = ensure_share_dir().await;
+    let metadata_file = get_metadata_file();
+    update_metadata_with_path(&metadata_file, update).await
+}
+
+async fn update_metadata_with_path<R>(
+    metadata_file: &Path,
+    update: impl FnOnce(&mut Metadata) -> R,
+) -> R {
     let _guard = METADATA_UPDATE_LOCK.lock().await;
-    let mut metadata = load_metadata().await;
+    let mut metadata = load_metadata_from_path(metadata_file).await;
     let result = update(&mut metadata);
-    save_metadata(&metadata).await;
+    save_metadata_to_path(metadata_file, &metadata).await;
     result
 }
 
@@ -147,64 +164,25 @@ fn default_kaos_name() -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::LazyLock;
-
     use tempfile::TempDir;
-    use tokio::sync::{Barrier, Mutex};
+    use tokio::sync::Barrier;
 
-    use super::{WorkDirMeta, load_metadata, update_metadata};
-
-    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::const_new(()));
-
-    struct EnvGuard {
-        key: &'static str,
-        prev: Option<String>,
-    }
-
-    impl EnvGuard {
-        fn set(key: &'static str, value: &str) -> Self {
-            let prev = std::env::var(key).ok();
-            // SAFETY: tests serialize env access with ENV_LOCK.
-            unsafe {
-                std::env::set_var(key, value);
-            }
-            Self { key, prev }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            if let Some(prev) = &self.prev {
-                // SAFETY: tests serialize env access with ENV_LOCK.
-                unsafe {
-                    std::env::set_var(self.key, prev);
-                }
-            } else {
-                // SAFETY: tests serialize env access with ENV_LOCK.
-                unsafe {
-                    std::env::remove_var(self.key);
-                }
-            }
-        }
-    }
+    use super::{WorkDirMeta, load_metadata_from_path, update_metadata_with_path};
 
     #[tokio::test]
     async fn update_metadata_serializes_concurrent_writes() {
-        let _lock = ENV_LOCK.lock().await;
         let share_dir = TempDir::new().expect("share dir");
-        let _env = EnvGuard::set(
-            "KIMI_SHARE_DIR",
-            share_dir.path().to_str().expect("share dir path"),
-        );
+        let metadata_file = share_dir.path().join("kimi.json");
 
         let n_tasks = 24usize;
         let barrier = std::sync::Arc::new(Barrier::new(n_tasks));
         let mut tasks = Vec::new();
         for idx in 0..n_tasks {
             let barrier = std::sync::Arc::clone(&barrier);
+            let metadata_file = metadata_file.clone();
             tasks.push(tokio::spawn(async move {
                 barrier.wait().await;
-                update_metadata(move |metadata| {
+                update_metadata_with_path(&metadata_file, move |metadata| {
                     metadata.work_dirs.push(WorkDirMeta {
                         path: format!("/tmp/work-{idx}"),
                         kaos: "local".to_string(),
@@ -218,7 +196,7 @@ mod tests {
             task.await.expect("join metadata task");
         }
 
-        let metadata = load_metadata().await;
+        let metadata = load_metadata_from_path(&metadata_file).await;
         assert_eq!(metadata.work_dirs.len(), n_tasks);
     }
 }

--- a/kimi-agent/src/metadata.rs
+++ b/kimi-agent/src/metadata.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+use std::sync::LazyLock;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use tracing::debug;
@@ -6,6 +8,9 @@ use tracing::debug;
 use kaos::{Kaos, KaosPath, LocalKaos, get_current_kaos};
 
 use crate::share::{ensure_share_dir, get_share_dir};
+
+static METADATA_UPDATE_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 pub fn get_metadata_file() -> PathBuf {
     get_share_dir().join("kimi.json")
@@ -103,16 +108,117 @@ pub async fn save_metadata(metadata: &Metadata) {
             metadata_file.display()
         )
     });
-    tokio::fs::write(&metadata_file, text)
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    let temp_file =
+        metadata_file.with_extension(format!("json.tmp-{}-{timestamp}", std::process::id()));
+    tokio::fs::write(&temp_file, text)
         .await
         .unwrap_or_else(|err| {
             panic!(
-                "Failed to write metadata file {}: {err}",
-                metadata_file.display()
+                "Failed to write temporary metadata file {}: {err}",
+                temp_file.display()
+            )
+        });
+    tokio::fs::rename(&temp_file, &metadata_file)
+        .await
+        .unwrap_or_else(|err| {
+            panic!(
+                "Failed to replace metadata file {} with {}: {err}",
+                metadata_file.display(),
+                temp_file.display()
             )
         });
 }
 
+pub async fn update_metadata<R>(update: impl FnOnce(&mut Metadata) -> R) -> R {
+    let _guard = METADATA_UPDATE_LOCK.lock().await;
+    let mut metadata = load_metadata().await;
+    let result = update(&mut metadata);
+    save_metadata(&metadata).await;
+    result
+}
+
 fn default_kaos_name() -> String {
     LocalKaos::new().storage_name()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::LazyLock;
+
+    use tempfile::TempDir;
+    use tokio::sync::{Barrier, Mutex};
+
+    use super::{WorkDirMeta, load_metadata, update_metadata};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::const_new(()));
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: tests serialize env access with ENV_LOCK.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(prev) = &self.prev {
+                // SAFETY: tests serialize env access with ENV_LOCK.
+                unsafe {
+                    std::env::set_var(self.key, prev);
+                }
+            } else {
+                // SAFETY: tests serialize env access with ENV_LOCK.
+                unsafe {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn update_metadata_serializes_concurrent_writes() {
+        let _lock = ENV_LOCK.lock().await;
+        let share_dir = TempDir::new().expect("share dir");
+        let _env = EnvGuard::set(
+            "KIMI_SHARE_DIR",
+            share_dir.path().to_str().expect("share dir path"),
+        );
+
+        let n_tasks = 24usize;
+        let barrier = std::sync::Arc::new(Barrier::new(n_tasks));
+        let mut tasks = Vec::new();
+        for idx in 0..n_tasks {
+            let barrier = std::sync::Arc::clone(&barrier);
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                update_metadata(move |metadata| {
+                    metadata.work_dirs.push(WorkDirMeta {
+                        path: format!("/tmp/work-{idx}"),
+                        kaos: "local".to_string(),
+                        last_session_id: Some(format!("session-{idx}")),
+                    });
+                })
+                .await;
+            }));
+        }
+        for task in tasks {
+            task.await.expect("join metadata task");
+        }
+
+        let metadata = load_metadata().await;
+        assert_eq!(metadata.work_dirs.len(), n_tasks);
+    }
 }

--- a/kimi-agent/src/session.rs
+++ b/kimi-agent/src/session.rs
@@ -321,6 +321,42 @@ impl Session {
     }
 }
 
+pub async fn post_run(session: &Session) -> anyhow::Result<()> {
+    let mut metadata = load_metadata().await;
+    let mut index = metadata.work_dirs.iter().position(|meta| {
+        meta.path == session.work_dir.to_string() && meta.kaos == session.work_dir_meta.kaos
+    });
+
+    if index.is_none() {
+        warn!(
+            "Work dir metadata missing when marking last session, recreating: {}",
+            session.work_dir.to_string_lossy()
+        );
+        let meta = session.work_dir_meta.clone();
+        metadata.work_dirs.push(meta);
+        index = Some(metadata.work_dirs.len() - 1);
+    }
+
+    let Some(idx) = index else {
+        save_metadata(&metadata).await;
+        return Ok(());
+    };
+
+    let meta = &mut metadata.work_dirs[idx];
+    if session.is_empty().await {
+        info!("Session {} has empty context, removing it", session.id);
+        session.delete().await;
+        if meta.last_session_id.as_deref() == Some(&session.id) {
+            meta.last_session_id = None;
+        }
+    } else {
+        meta.last_session_id = Some(session.id.clone());
+    }
+
+    save_metadata(&metadata).await;
+    Ok(())
+}
+
 async fn migrate_session_context_file(sessions_dir: &Path, session_id: &str) {
     let old_context_file = sessions_dir.join(format!("{session_id}.jsonl"));
     let new_context_file = sessions_dir.join(session_id).join("context.jsonl");

--- a/kimi-agent/src/session.rs
+++ b/kimi-agent/src/session.rs
@@ -9,6 +9,7 @@ use kosong::message::{Message, Role};
 use tracing::{debug, error, info, warn};
 
 use crate::metadata::{WorkDirMeta, load_metadata, update_metadata};
+use crate::session_id::normalize_session_id;
 use crate::wire::{TurnBegin, UserInput, WireFile, WireMessage};
 
 #[derive(Clone, Debug)]
@@ -91,7 +92,13 @@ impl Session {
         })
         .await;
 
-        let session_id = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let session_id = session_id
+            .map(|session_id| {
+                normalize_session_id(&session_id).unwrap_or_else(|err| {
+                    panic!("Invalid session ID `{session_id}`: {err}");
+                })
+            })
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let sessions_dir = work_dir_meta.ensure_sessions_dir().await;
         let session_dir = sessions_dir.join(&session_id);
         tokio::fs::create_dir_all(&session_dir)
@@ -154,6 +161,13 @@ impl Session {
     }
 
     pub async fn find(work_dir: KaosPath, session_id: &str) -> Option<Session> {
+        let session_id = match normalize_session_id(session_id) {
+            Ok(session_id) => session_id,
+            Err(err) => {
+                warn!("Ignoring invalid session ID `{session_id}`: {err}");
+                return None;
+            }
+        };
         let work_dir = work_dir.canonical();
         debug!(
             "Finding session for work directory: {}, session ID: {}",
@@ -170,9 +184,9 @@ impl Session {
         };
 
         let sessions_dir = work_dir_meta.ensure_sessions_dir().await;
-        migrate_session_context_file(&sessions_dir, session_id).await;
+        migrate_session_context_file(&sessions_dir, &session_id).await;
 
-        let session_dir = sessions_dir.join(session_id);
+        let session_dir = sessions_dir.join(&session_id);
         if tokio::fs::metadata(&session_dir)
             .await
             .map(|meta| !meta.is_dir())
@@ -188,7 +202,7 @@ impl Session {
         }
 
         let mut session = Session {
-            id: session_id.to_string(),
+            id: session_id,
             work_dir,
             work_dir_meta,
             context_file,
@@ -256,6 +270,13 @@ impl Session {
 
         let mut sessions = Vec::new();
         for session_id in session_ids {
+            let session_id = match normalize_session_id(&session_id) {
+                Ok(session_id) => session_id,
+                Err(err) => {
+                    warn!("Skipping invalid session ID entry `{session_id}`: {err}");
+                    continue;
+                }
+            };
             migrate_session_context_file(&sessions_dir, &session_id).await;
             let session_dir = sessions_dir.join(&session_id);
             if tokio::fs::metadata(&session_dir)

--- a/kimi-agent/src/session.rs
+++ b/kimi-agent/src/session.rs
@@ -8,7 +8,7 @@ use kaos::KaosPath;
 use kosong::message::{Message, Role};
 use tracing::{debug, error, info, warn};
 
-use crate::metadata::{WorkDirMeta, load_metadata, save_metadata};
+use crate::metadata::{WorkDirMeta, load_metadata, update_metadata};
 use crate::wire::{TurnBegin, UserInput, WireFile, WireMessage};
 
 #[derive(Clone, Debug)]
@@ -84,10 +84,12 @@ impl Session {
             "Creating new session for work directory: {}",
             work_dir.to_string_lossy()
         );
-        let mut metadata = load_metadata().await;
-        let work_dir_meta = metadata
-            .get_work_dir_meta(&work_dir)
-            .unwrap_or_else(|| metadata.new_work_dir_meta(&work_dir));
+        let work_dir_meta = update_metadata(|metadata| {
+            metadata
+                .get_work_dir_meta(&work_dir)
+                .unwrap_or_else(|| metadata.new_work_dir_meta(&work_dir))
+        })
+        .await;
 
         let session_id = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let sessions_dir = work_dir_meta.ensure_sessions_dir().await;
@@ -137,8 +139,6 @@ impl Session {
                     context_file.display()
                 )
             });
-
-        save_metadata(&metadata).await;
 
         let mut session = Session {
             id: session_id,
@@ -322,38 +322,45 @@ impl Session {
 }
 
 pub async fn post_run(session: &Session) -> anyhow::Result<()> {
-    let mut metadata = load_metadata().await;
-    let mut index = metadata.work_dirs.iter().position(|meta| {
-        meta.path == session.work_dir.to_string() && meta.kaos == session.work_dir_meta.kaos
-    });
-
-    if index.is_none() {
-        warn!(
-            "Work dir metadata missing when marking last session, recreating: {}",
-            session.work_dir.to_string_lossy()
-        );
-        let meta = session.work_dir_meta.clone();
-        metadata.work_dirs.push(meta);
-        index = Some(metadata.work_dirs.len() - 1);
-    }
-
-    let Some(idx) = index else {
-        save_metadata(&metadata).await;
-        return Ok(());
-    };
-
-    let meta = &mut metadata.work_dirs[idx];
-    if session.is_empty().await {
+    let is_empty = session.is_empty().await;
+    if is_empty {
         info!("Session {} has empty context, removing it", session.id);
         session.delete().await;
-        if meta.last_session_id.as_deref() == Some(&session.id) {
-            meta.last_session_id = None;
-        }
-    } else {
-        meta.last_session_id = Some(session.id.clone());
     }
 
-    save_metadata(&metadata).await;
+    let work_dir = session.work_dir.to_string();
+    let work_dir_kaos = session.work_dir_meta.kaos.clone();
+    let work_dir_meta = session.work_dir_meta.clone();
+    let session_id = session.id.clone();
+    update_metadata(move |metadata| {
+        let mut index = metadata
+            .work_dirs
+            .iter()
+            .position(|meta| meta.path == work_dir && meta.kaos == work_dir_kaos);
+
+        if index.is_none() {
+            warn!(
+                "Work dir metadata missing when marking last session, recreating: {}",
+                work_dir_meta.path
+            );
+            metadata.work_dirs.push(work_dir_meta);
+            index = Some(metadata.work_dirs.len() - 1);
+        }
+
+        let Some(idx) = index else {
+            return;
+        };
+        let meta = &mut metadata.work_dirs[idx];
+        if is_empty {
+            if meta.last_session_id.as_deref() == Some(session_id.as_str()) {
+                meta.last_session_id = None;
+            }
+        } else {
+            meta.last_session_id = Some(session_id);
+        }
+    })
+    .await;
+
     Ok(())
 }
 

--- a/kimi-agent/src/session_id.rs
+++ b/kimi-agent/src/session_id.rs
@@ -1,0 +1,55 @@
+use std::path::{Component, Path};
+
+pub fn normalize_session_id(session_id: &str) -> anyhow::Result<String> {
+    let normalized = session_id.trim();
+    if normalized.is_empty() {
+        anyhow::bail!("session_id cannot be empty");
+    }
+    if normalized.len() > 128 {
+        anyhow::bail!("session_id is too long (max 128 chars)");
+    }
+    if normalized.contains('/') || normalized.contains('\\') {
+        anyhow::bail!("session_id cannot contain path separators");
+    }
+    if normalized == "." || normalized == ".." {
+        anyhow::bail!("session_id cannot be dot segments");
+    }
+    if !normalized
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        anyhow::bail!("session_id contains invalid characters");
+    }
+
+    let mut components = Path::new(normalized).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => {}
+        _ => anyhow::bail!("session_id must be a single path segment"),
+    }
+
+    Ok(normalized.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_session_id;
+
+    #[test]
+    fn normalize_session_id_accepts_valid_session_id() {
+        assert_eq!(normalize_session_id("abc").unwrap(), "abc");
+        assert_eq!(normalize_session_id(" abc-def ").unwrap(), "abc-def");
+    }
+
+    #[test]
+    fn normalize_session_id_rejects_invalid_session_id() {
+        assert!(normalize_session_id("").is_err());
+        assert!(normalize_session_id("   ").is_err());
+        assert!(normalize_session_id(".").is_err());
+        assert!(normalize_session_id("..").is_err());
+        assert!(normalize_session_id("a/b").is_err());
+        assert!(normalize_session_id("a\\b").is_err());
+        assert!(normalize_session_id("a:b").is_err());
+        assert!(normalize_session_id("a b").is_err());
+        assert!(normalize_session_id(&"a".repeat(129)).is_err());
+    }
+}

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -1,8 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
 
+use axum::extract::Query;
 use axum::extract::State;
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
 use axum::response::{IntoResponse, Response};
@@ -11,14 +13,17 @@ use axum::{Router, http::StatusCode};
 use futures::{SinkExt, StreamExt};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
+use kaos::KaosPath;
 use kosong::chat_provider::ChatProviderError;
 use kosong::tooling::tool_error;
 
+use crate::app::{ConfigInput, CreateOptions, KimiCLI};
+use crate::config::Config;
 use crate::constant::{NAME, VERSION};
+use crate::session::{Session, post_run as post_run_session};
 use crate::soul::kimisoul::KimiSoul;
 use crate::soul::{LLMNotSet, LLMNotSupported, MaxStepsReached, RunCancelled, Soul, run_soul};
 use crate::utils::{Queue, QueueShutDown};
@@ -59,6 +64,10 @@ impl WireRpcState {
 
     fn write_queue(&self) -> Queue<Value> {
         self.write_queue.clone()
+    }
+
+    fn session(&self) -> Session {
+        self.soul.runtime().session.clone()
     }
 
     async fn handle_json_line(&self, line: &str) {
@@ -621,9 +630,32 @@ impl WireServer {
 }
 
 pub struct WireWsServer {
-    rpc: WireRpcState,
+    runtime_mode: WsRuntimeMode,
     listen_addr: SocketAddr,
     path: String,
+    default_session_id: String,
+}
+
+#[derive(Clone)]
+pub struct WsSessionRuntimeOptions {
+    pub work_dir: KaosPath,
+    pub default_session_id: String,
+    pub config: Config,
+    pub model_name: Option<String>,
+    pub thinking: Option<bool>,
+    pub yolo: bool,
+    pub agent_file: Option<PathBuf>,
+    pub mcp_configs: Vec<Value>,
+    pub skills_dir: Option<KaosPath>,
+    pub max_steps_per_turn: Option<i64>,
+    pub max_retries_per_step: Option<i64>,
+    pub max_ralph_iterations: Option<i64>,
+}
+
+#[derive(Clone)]
+enum WsRuntimeMode {
+    SingleSoul(Arc<KimiSoul>),
+    SessionFactory(Arc<WsSessionRuntimeOptions>),
 }
 
 impl WireWsServer {
@@ -634,10 +666,29 @@ impl WireWsServer {
     ) -> anyhow::Result<Self> {
         let path = path.into();
         let path = normalize_ws_path(&path)?;
+        let default_session_id = normalize_session_id(&soul.runtime().session.id)?;
         Ok(Self {
-            rpc: WireRpcState::new(soul),
+            runtime_mode: WsRuntimeMode::SingleSoul(soul),
             listen_addr,
             path,
+            default_session_id,
+        })
+    }
+
+    pub fn new_multi(
+        options: WsSessionRuntimeOptions,
+        listen_addr: SocketAddr,
+        path: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        let path = path.into();
+        let path = normalize_ws_path(&path)?;
+        let mut options = options;
+        options.default_session_id = normalize_session_id(&options.default_session_id)?;
+        Ok(Self {
+            runtime_mode: WsRuntimeMode::SessionFactory(Arc::new(options.clone())),
+            listen_addr,
+            path,
+            default_session_id: options.default_session_id,
         })
     }
 
@@ -657,74 +708,163 @@ impl WireWsServer {
             "Starting Wire server on websocket"
         );
 
-        let state = Arc::new(WsServerState::new(self.rpc.clone()));
+        let state = Arc::new(WsServerState::new(
+            self.runtime_mode.clone(),
+            self.default_session_id.clone(),
+        ));
         let app = Router::new()
             .route(&self.path, get(ws_upgrade_handler))
             .with_state(Arc::clone(&state));
 
-        axum::serve(listener, app)
-            .with_graceful_shutdown(wait_for_ws_shutdown(Arc::clone(&state)))
-            .await?;
-
-        self.rpc.shutdown().await;
+        axum::serve(listener, app).await?;
         Ok(())
     }
 }
 
 struct WsServerState {
-    rpc: WireRpcState,
-    active_client: AtomicBool,
-    shutdown: Notify,
+    runtime_mode: WsRuntimeMode,
+    default_session_id: String,
+    active_sessions: Mutex<HashSet<String>>,
 }
 
 impl WsServerState {
-    fn new(rpc: WireRpcState) -> Self {
+    fn new(runtime_mode: WsRuntimeMode, default_session_id: String) -> Self {
         Self {
-            rpc,
-            active_client: AtomicBool::new(false),
-            shutdown: Notify::new(),
+            runtime_mode,
+            default_session_id,
+            active_sessions: Mutex::new(HashSet::new()),
+        }
+    }
+
+    fn resolve_session_id(&self, requested_session_id: Option<&str>) -> anyhow::Result<String> {
+        match (&self.runtime_mode, requested_session_id) {
+            (WsRuntimeMode::SingleSoul(_), Some(requested)) => {
+                let normalized = normalize_session_id(requested)?;
+                if normalized != self.default_session_id {
+                    anyhow::bail!(
+                        "single-session websocket server only accepts session_id `{}`",
+                        self.default_session_id
+                    );
+                }
+                Ok(normalized)
+            }
+            (_, Some(requested)) => normalize_session_id(requested),
+            (_, None) => Ok(self.default_session_id.clone()),
+        }
+    }
+
+    fn lock_active_sessions(&self) -> MutexGuard<'_, HashSet<String>> {
+        match self.active_sessions.lock() {
+            Ok(guard) => guard,
+            Err(err) => err.into_inner(),
+        }
+    }
+
+    fn try_acquire_session(&self, session_id: &str) -> bool {
+        let mut sessions = self.lock_active_sessions();
+        if sessions.contains(session_id) {
+            return false;
+        }
+        sessions.insert(session_id.to_string());
+        true
+    }
+
+    fn release_session(&self, session_id: &str) {
+        self.lock_active_sessions().remove(session_id);
+    }
+
+    async fn create_rpc(&self, session_id: &str) -> anyhow::Result<WireRpcState> {
+        match &self.runtime_mode {
+            WsRuntimeMode::SingleSoul(soul) => Ok(WireRpcState::new(Arc::clone(soul))),
+            WsRuntimeMode::SessionFactory(options) => {
+                let session = match Session::find(options.work_dir.clone(), session_id).await {
+                    Some(session) => session,
+                    None => {
+                        Session::create(
+                            options.work_dir.clone(),
+                            Some(session_id.to_string()),
+                            None,
+                        )
+                        .await
+                    }
+                };
+
+                let cli = KimiCLI::create(
+                    session,
+                    CreateOptions {
+                        config: Some(ConfigInput::Inline(Box::new(options.config.clone()))),
+                        model_name: options.model_name.clone(),
+                        thinking: options.thinking,
+                        yolo: options.yolo,
+                        agent_file: options.agent_file.clone(),
+                        mcp_configs: options.mcp_configs.clone(),
+                        skills_dir: options.skills_dir.clone(),
+                        max_steps_per_turn: options.max_steps_per_turn,
+                        max_retries_per_step: options.max_retries_per_step,
+                        max_ralph_iterations: options.max_ralph_iterations,
+                    },
+                )
+                .await?;
+
+                Ok(WireRpcState::new(cli.soul()))
+            }
         }
     }
 }
 
-async fn wait_for_ws_shutdown(state: Arc<WsServerState>) {
-    state.shutdown.notified().await;
-}
-
 async fn ws_upgrade_handler(
     State(state): State<Arc<WsServerState>>,
+    Query(query): Query<HashMap<String, String>>,
     ws: WebSocketUpgrade,
 ) -> Response {
-    if state
-        .active_client
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
+    let session_id = match state.resolve_session_id(query.get("session_id").map(String::as_str)) {
+        Ok(session_id) => session_id,
+        Err(err) => return (StatusCode::BAD_REQUEST, err.to_string()).into_response(),
+    };
+
+    if !state.try_acquire_session(&session_id) {
         return (
             StatusCode::CONFLICT,
-            "Only one websocket client is allowed for this wire server.",
+            format!("Session `{session_id}` already has an active websocket client."),
         )
             .into_response();
     }
 
     let state_for_upgrade = Arc::clone(&state);
+    let session_id_for_upgrade = session_id.clone();
     let state_for_failed_upgrade = Arc::clone(&state);
+    let session_id_for_failed_upgrade = session_id.clone();
     ws.on_failed_upgrade(move |err| {
-        warn!("Wire websocket upgrade failed: {}", err);
-        state_for_failed_upgrade
-            .active_client
-            .store(false, Ordering::SeqCst);
+        warn!(
+            session_id = %session_id_for_failed_upgrade,
+            "Wire websocket upgrade failed: {}",
+            err
+        );
+        state_for_failed_upgrade.release_session(&session_id_for_failed_upgrade);
     })
     .on_upgrade(move |socket| async move {
-        handle_ws_socket(socket, state_for_upgrade).await;
+        handle_ws_socket(socket, state_for_upgrade, session_id_for_upgrade).await;
     })
     .into_response()
 }
 
-async fn handle_ws_socket(socket: WebSocket, state: Arc<WsServerState>) {
+async fn handle_ws_socket(socket: WebSocket, state: Arc<WsServerState>, session_id: String) {
+    let rpc = match state.create_rpc(&session_id).await {
+        Ok(rpc) => rpc,
+        Err(err) => {
+            error!(
+                session_id = %session_id,
+                "Failed to create wire session runtime: {}",
+                err
+            );
+            state.release_session(&session_id);
+            return;
+        }
+    };
+
     let (mut sender, mut receiver) = socket.split();
 
-    let write_queue = state.rpc.write_queue();
+    let write_queue = rpc.write_queue();
     let write_task = tokio::spawn(async move {
         loop {
             let msg = match write_queue.get().await {
@@ -753,32 +893,41 @@ async fn handle_ws_socket(socket: WebSocket, state: Arc<WsServerState>) {
     while let Some(frame) = receiver.next().await {
         match frame {
             Ok(WsMessage::Text(text)) => {
-                state.rpc.handle_json_line(text.as_str()).await;
+                rpc.handle_json_line(text.as_str()).await;
             }
             Ok(WsMessage::Binary(binary)) => match std::str::from_utf8(binary.as_ref()) {
-                Ok(text) => state.rpc.handle_json_line(text).await,
+                Ok(text) => rpc.handle_json_line(text).await,
                 Err(_) => {
-                    state
-                        .rpc
-                        .send_error_nullable(error_codes::INVALID_REQUEST, "Invalid request", None)
+                    rpc.send_error_nullable(error_codes::INVALID_REQUEST, "Invalid request", None)
                         .await;
                 }
             },
             Ok(WsMessage::Ping(_)) | Ok(WsMessage::Pong(_)) => {}
             Ok(WsMessage::Close(_)) => {
-                info!("websocket closed by client, Wire server exiting");
+                info!(session_id = %session_id, "websocket closed by client");
                 break;
             }
             Err(err) => {
-                error!("Wire websocket read loop error: {:?}", err);
+                error!(
+                    session_id = %session_id,
+                    "Wire websocket read loop error: {:?}",
+                    err
+                );
                 break;
             }
         }
     }
 
-    // Stop accepting new connections before tearing down RPC state.
-    state.shutdown.notify_waiters();
-    state.rpc.shutdown().await;
+    let session = rpc.session();
+    rpc.shutdown().await;
+    if let Err(err) = post_run_session(&session).await {
+        warn!(
+            session_id = %session_id,
+            "Failed to finalize session metadata after websocket close: {}",
+            err
+        );
+    }
+    state.release_session(&session_id);
     let _ = write_task.await;
 }
 
@@ -792,6 +941,17 @@ fn normalize_ws_path(path: &str) -> anyhow::Result<String> {
     }
     if normalized.contains('?') || normalized.contains('#') {
         anyhow::bail!("wire path cannot contain query or fragment");
+    }
+    Ok(normalized.to_string())
+}
+
+fn normalize_session_id(session_id: &str) -> anyhow::Result<String> {
+    let normalized = session_id.trim();
+    if normalized.is_empty() {
+        anyhow::bail!("session_id cannot be empty");
+    }
+    if normalized.contains('/') || normalized.contains('\\') {
+        anyhow::bail!("session_id cannot contain path separators");
     }
     Ok(normalized.to_string())
 }
@@ -856,7 +1016,7 @@ async fn request_tool_call(
 
 #[cfg(test)]
 mod tests {
-    use super::normalize_ws_path;
+    use super::{normalize_session_id, normalize_ws_path};
 
     #[test]
     fn normalize_ws_path_accepts_valid_path() {
@@ -870,5 +1030,19 @@ mod tests {
         assert!(normalize_ws_path("wire").is_err());
         assert!(normalize_ws_path("/wire?x=1").is_err());
         assert!(normalize_ws_path("/wire#frag").is_err());
+    }
+
+    #[test]
+    fn normalize_session_id_accepts_valid_session_id() {
+        assert_eq!(normalize_session_id("abc").unwrap(), "abc");
+        assert_eq!(normalize_session_id(" abc-def ").unwrap(), "abc-def");
+    }
+
+    #[test]
+    fn normalize_session_id_rejects_invalid_session_id() {
+        assert!(normalize_session_id("").is_err());
+        assert!(normalize_session_id("   ").is_err());
+        assert!(normalize_session_id("a/b").is_err());
+        assert!(normalize_session_id("a\\b").is_err());
     }
 }

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::path::{Component, Path};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
@@ -26,6 +25,7 @@ use crate::app::{ConfigInput, CreateOptions, KimiCLI};
 use crate::config::Config;
 use crate::constant::{NAME, VERSION};
 use crate::session::{Session, post_run as post_run_session};
+use crate::session_id::normalize_session_id;
 use crate::soul::kimisoul::KimiSoul;
 use crate::soul::{LLMNotSet, LLMNotSupported, MaxStepsReached, RunCancelled, Soul, run_soul};
 use crate::utils::{Queue, QueueShutDown};
@@ -940,36 +940,6 @@ fn normalize_ws_path(path: &str) -> anyhow::Result<String> {
     Ok(normalized.to_string())
 }
 
-fn normalize_session_id(session_id: &str) -> anyhow::Result<String> {
-    let normalized = session_id.trim();
-    if normalized.is_empty() {
-        anyhow::bail!("session_id cannot be empty");
-    }
-    if normalized.len() > 128 {
-        anyhow::bail!("session_id is too long (max 128 chars)");
-    }
-    if normalized.contains('/') || normalized.contains('\\') {
-        anyhow::bail!("session_id cannot contain path separators");
-    }
-    if normalized == "." || normalized == ".." {
-        anyhow::bail!("session_id cannot be dot segments");
-    }
-    if !normalized
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
-    {
-        anyhow::bail!("session_id contains invalid characters");
-    }
-
-    let mut components = Path::new(normalized).components();
-    match (components.next(), components.next()) {
-        (Some(Component::Normal(_)), None) => {}
-        _ => anyhow::bail!("session_id must be a single path segment"),
-    }
-
-    Ok(normalized.to_string())
-}
-
 async fn stream_wire_messages(
     write_queue: Queue<Value>,
     pending: Arc<tokio::sync::Mutex<HashMap<String, PendingRequest>>>,
@@ -1035,7 +1005,7 @@ mod tests {
 
     use tokio_util::sync::CancellationToken;
 
-    use super::{ActiveTurn, cancel_and_wait_active_turn, normalize_session_id, normalize_ws_path};
+    use super::{ActiveTurn, cancel_and_wait_active_turn, normalize_ws_path};
 
     #[test]
     fn normalize_ws_path_accepts_valid_path() {
@@ -1049,25 +1019,6 @@ mod tests {
         assert!(normalize_ws_path("wire").is_err());
         assert!(normalize_ws_path("/wire?x=1").is_err());
         assert!(normalize_ws_path("/wire#frag").is_err());
-    }
-
-    #[test]
-    fn normalize_session_id_accepts_valid_session_id() {
-        assert_eq!(normalize_session_id("abc").unwrap(), "abc");
-        assert_eq!(normalize_session_id(" abc-def ").unwrap(), "abc-def");
-    }
-
-    #[test]
-    fn normalize_session_id_rejects_invalid_session_id() {
-        assert!(normalize_session_id("").is_err());
-        assert!(normalize_session_id("   ").is_err());
-        assert!(normalize_session_id(".").is_err());
-        assert!(normalize_session_id("..").is_err());
-        assert!(normalize_session_id("a/b").is_err());
-        assert!(normalize_session_id("a\\b").is_err());
-        assert!(normalize_session_id("a:b").is_err());
-        assert!(normalize_session_id("a b").is_err());
-        assert!(normalize_session_id(&"a".repeat(129)).is_err());
     }
 
     #[tokio::test]

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -631,10 +631,9 @@ impl WireServer {
 }
 
 pub struct WireWsServer {
-    runtime_mode: WsRuntimeMode,
+    options: Arc<WsSessionRuntimeOptions>,
     listen_addr: SocketAddr,
     path: String,
-    default_session_id: String,
 }
 
 #[derive(Clone)]
@@ -653,30 +652,8 @@ pub struct WsSessionRuntimeOptions {
     pub max_ralph_iterations: Option<i64>,
 }
 
-#[derive(Clone)]
-enum WsRuntimeMode {
-    SingleSoul(Arc<KimiSoul>),
-    SessionFactory(Arc<WsSessionRuntimeOptions>),
-}
-
 impl WireWsServer {
     pub fn new(
-        soul: Arc<KimiSoul>,
-        listen_addr: SocketAddr,
-        path: impl Into<String>,
-    ) -> anyhow::Result<Self> {
-        let path = path.into();
-        let path = normalize_ws_path(&path)?;
-        let default_session_id = normalize_session_id(&soul.runtime().session.id)?;
-        Ok(Self {
-            runtime_mode: WsRuntimeMode::SingleSoul(soul),
-            listen_addr,
-            path,
-            default_session_id,
-        })
-    }
-
-    pub fn new_multi(
         options: WsSessionRuntimeOptions,
         listen_addr: SocketAddr,
         path: impl Into<String>,
@@ -686,10 +663,9 @@ impl WireWsServer {
         let mut options = options;
         options.default_session_id = normalize_session_id(&options.default_session_id)?;
         Ok(Self {
-            runtime_mode: WsRuntimeMode::SessionFactory(Arc::new(options.clone())),
+            options: Arc::new(options),
             listen_addr,
             path,
-            default_session_id: options.default_session_id,
         })
     }
 
@@ -709,10 +685,7 @@ impl WireWsServer {
             "Starting Wire server on websocket"
         );
 
-        let state = Arc::new(WsServerState::new(
-            self.runtime_mode.clone(),
-            self.default_session_id.clone(),
-        ));
+        let state = Arc::new(WsServerState::new(Arc::clone(&self.options)));
         let app = Router::new()
             .route(&self.path, get(ws_upgrade_handler))
             .with_state(Arc::clone(&state));
@@ -723,34 +696,22 @@ impl WireWsServer {
 }
 
 struct WsServerState {
-    runtime_mode: WsRuntimeMode,
-    default_session_id: String,
+    options: Arc<WsSessionRuntimeOptions>,
     active_sessions: Mutex<HashSet<String>>,
 }
 
 impl WsServerState {
-    fn new(runtime_mode: WsRuntimeMode, default_session_id: String) -> Self {
+    fn new(options: Arc<WsSessionRuntimeOptions>) -> Self {
         Self {
-            runtime_mode,
-            default_session_id,
+            options,
             active_sessions: Mutex::new(HashSet::new()),
         }
     }
 
     fn resolve_session_id(&self, requested_session_id: Option<&str>) -> anyhow::Result<String> {
-        match (&self.runtime_mode, requested_session_id) {
-            (WsRuntimeMode::SingleSoul(_), Some(requested)) => {
-                let normalized = normalize_session_id(requested)?;
-                if normalized != self.default_session_id {
-                    anyhow::bail!(
-                        "single-session websocket server only accepts session_id `{}`",
-                        self.default_session_id
-                    );
-                }
-                Ok(normalized)
-            }
-            (_, Some(requested)) => normalize_session_id(requested),
-            (_, None) => Ok(self.default_session_id.clone()),
+        match requested_session_id {
+            Some(requested) => normalize_session_id(requested),
+            None => Ok(self.options.default_session_id.clone()),
         }
     }
 
@@ -775,41 +736,32 @@ impl WsServerState {
     }
 
     async fn create_rpc(&self, session_id: &str) -> anyhow::Result<WireRpcState> {
-        match &self.runtime_mode {
-            WsRuntimeMode::SingleSoul(soul) => Ok(WireRpcState::new(Arc::clone(soul))),
-            WsRuntimeMode::SessionFactory(options) => {
-                let session = match Session::find(options.work_dir.clone(), session_id).await {
-                    Some(session) => session,
-                    None => {
-                        Session::create(
-                            options.work_dir.clone(),
-                            Some(session_id.to_string()),
-                            None,
-                        )
-                        .await
-                    }
-                };
-
-                let cli = KimiCLI::create(
-                    session,
-                    CreateOptions {
-                        config: Some(ConfigInput::Inline(Box::new(options.config.clone()))),
-                        model_name: options.model_name.clone(),
-                        thinking: options.thinking,
-                        yolo: options.yolo,
-                        agent_file: options.agent_file.clone(),
-                        mcp_configs: options.mcp_configs.clone(),
-                        skills_dir: options.skills_dir.clone(),
-                        max_steps_per_turn: options.max_steps_per_turn,
-                        max_retries_per_step: options.max_retries_per_step,
-                        max_ralph_iterations: options.max_ralph_iterations,
-                    },
-                )
-                .await?;
-
-                Ok(WireRpcState::new(cli.soul()))
+        let options = &self.options;
+        let session = match Session::find(options.work_dir.clone(), session_id).await {
+            Some(session) => session,
+            None => {
+                Session::create(options.work_dir.clone(), Some(session_id.to_string()), None).await
             }
-        }
+        };
+
+        let cli = KimiCLI::create(
+            session,
+            CreateOptions {
+                config: Some(ConfigInput::Inline(Box::new(options.config.clone()))),
+                model_name: options.model_name.clone(),
+                thinking: options.thinking,
+                yolo: options.yolo,
+                agent_file: options.agent_file.clone(),
+                mcp_configs: options.mcp_configs.clone(),
+                skills_dir: options.skills_dir.clone(),
+                max_steps_per_turn: options.max_steps_per_turn,
+                max_retries_per_step: options.max_retries_per_step,
+                max_ralph_iterations: options.max_ralph_iterations,
+            },
+        )
+        .await?;
+
+        Ok(WireRpcState::new(cli.soul()))
     }
 }
 

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::path::{Component, Path};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
 
 use axum::extract::Query;
@@ -45,12 +46,19 @@ enum PendingRequest {
     ToolCall(ToolCallRequest),
 }
 
+struct ActiveTurn {
+    id: u64,
+    cancel_token: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
 #[derive(Clone)]
 struct WireRpcState {
     soul: Arc<KimiSoul>,
     write_queue: Queue<Value>,
     pending: Arc<tokio::sync::Mutex<HashMap<String, PendingRequest>>>,
-    cancel_token: Arc<tokio::sync::Mutex<Option<CancellationToken>>>,
+    active_turn: Arc<tokio::sync::Mutex<Option<ActiveTurn>>>,
+    next_turn_id: Arc<AtomicU64>,
 }
 
 impl WireRpcState {
@@ -59,7 +67,8 @@ impl WireRpcState {
             soul,
             write_queue: Queue::new(),
             pending: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-            cancel_token: Arc::new(tokio::sync::Mutex::new(None)),
+            active_turn: Arc::new(tokio::sync::Mutex::new(None)),
+            next_turn_id: Arc::new(AtomicU64::new(1)),
         }
     }
 
@@ -165,7 +174,7 @@ impl WireRpcState {
         let Some(id) = msg.id.clone() else {
             return;
         };
-        if self.cancel_token.lock().await.is_some() {
+        if self.active_turn.lock().await.is_some() {
             self.send_error(
                 id,
                 error_codes::INVALID_STATE,
@@ -248,15 +257,6 @@ impl WireRpcState {
         let Some(id) = msg.id.clone() else {
             return;
         };
-        if self.cancel_token.lock().await.is_some() {
-            self.send_error(
-                id,
-                error_codes::INVALID_STATE,
-                "An agent turn is already in progress",
-            )
-            .await;
-            return;
-        }
         let params: PromptParams = match msg
             .params
             .clone()
@@ -274,16 +274,27 @@ impl WireRpcState {
             }
         };
 
+        let turn_id = self.next_turn_id.fetch_add(1, Ordering::Relaxed);
         let cancel_token = CancellationToken::new();
-        let cancel_slot = Arc::clone(&self.cancel_token);
-        *cancel_slot.lock().await = Some(cancel_token.clone());
-
+        let turn_cancel_token = cancel_token.clone();
+        let active_turn_slot = Arc::clone(&self.active_turn);
         let soul = Arc::clone(&self.soul);
         let write_queue = self.write_queue.clone();
         let pending = Arc::clone(&self.pending);
         let wire_file = Some(self.soul.runtime().session.wire_file());
+        let mut active_turn = self.active_turn.lock().await;
+        if active_turn.is_some() {
+            drop(active_turn);
+            self.send_error(
+                id,
+                error_codes::INVALID_STATE,
+                "An agent turn is already in progress",
+            )
+            .await;
+            return;
+        }
 
-        tokio::spawn(async move {
+        let task = tokio::spawn(async move {
             let write_queue_for_stream = write_queue.clone();
             let pending_for_stream = Arc::clone(&pending);
             let run_handle = tokio::task::spawn_blocking(move || {
@@ -298,7 +309,7 @@ impl WireRpcState {
                             wire,
                         )
                     },
-                    cancel_token,
+                    turn_cancel_token,
                     wire_file,
                 ))
             });
@@ -306,8 +317,6 @@ impl WireRpcState {
                 Ok(result) => result,
                 Err(err) => Err(anyhow::anyhow!("Wire run task failed: {err}")),
             };
-
-            *cancel_slot.lock().await = None;
 
             match run_result {
                 Ok(()) => {
@@ -392,6 +401,15 @@ impl WireRpcState {
                     }
                 }
             }
+            let mut slot = active_turn_slot.lock().await;
+            if slot.as_ref().is_some_and(|turn| turn.id == turn_id) {
+                *slot = None;
+            }
+        });
+        *active_turn = Some(ActiveTurn {
+            id: turn_id,
+            cancel_token,
+            task,
         });
     }
 
@@ -399,8 +417,13 @@ impl WireRpcState {
         let Some(id) = msg.id.clone() else {
             return;
         };
-        let guard = self.cancel_token.lock().await;
-        let Some(token) = guard.as_ref() else {
+        let cancel_token = self
+            .active_turn
+            .lock()
+            .await
+            .as_ref()
+            .map(|turn| turn.cancel_token.clone());
+        let Some(token) = cancel_token else {
             self.send_error(
                 id,
                 error_codes::INVALID_STATE,
@@ -534,7 +557,7 @@ impl WireRpcState {
         }
     }
 
-    async fn shutdown(&self) {
+    async fn reject_pending_requests(&self) {
         let pending = {
             let mut pending = self.pending.lock().await;
             std::mem::take(&mut *pending)
@@ -554,12 +577,31 @@ impl WireRpcState {
                 }
             }
         }
+    }
 
-        if let Some(token) = self.cancel_token.lock().await.take() {
-            token.cancel();
-        }
+    async fn shutdown(&self) {
+        self.reject_pending_requests().await;
+
+        cancel_and_wait_active_turn(&self.active_turn).await;
+
+        self.reject_pending_requests().await;
 
         self.write_queue.shutdown(false);
+    }
+}
+
+async fn cancel_and_wait_active_turn(
+    active_turn_slot: &Arc<tokio::sync::Mutex<Option<ActiveTurn>>>,
+) {
+    let active_turn = {
+        let mut active_turn = active_turn_slot.lock().await;
+        active_turn.take()
+    };
+    if let Some(active_turn) = active_turn {
+        active_turn.cancel_token.cancel();
+        if let Err(err) = active_turn.task.await {
+            warn!("Wire turn task join failed during shutdown: {:?}", err);
+        }
     }
 }
 
@@ -988,7 +1030,12 @@ async fn request_tool_call(
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_session_id, normalize_ws_path};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::{ActiveTurn, cancel_and_wait_active_turn, normalize_session_id, normalize_ws_path};
 
     #[test]
     fn normalize_ws_path_accepts_valid_path() {
@@ -1021,5 +1068,31 @@ mod tests {
         assert!(normalize_session_id("a:b").is_err());
         assert!(normalize_session_id("a b").is_err());
         assert!(normalize_session_id(&"a".repeat(129)).is_err());
+    }
+
+    #[tokio::test]
+    async fn cancel_and_wait_active_turn_waits_for_turn_exit() {
+        let active_turn_slot = Arc::new(tokio::sync::Mutex::new(None));
+        let cancel_token = CancellationToken::new();
+        let task_cancel_token = cancel_token.clone();
+        let task = tokio::spawn(async move {
+            task_cancel_token.cancelled().await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        });
+
+        *active_turn_slot.lock().await = Some(ActiveTurn {
+            id: 1,
+            cancel_token,
+            task,
+        });
+
+        let started_at = Instant::now();
+        cancel_and_wait_active_turn(&active_turn_slot).await;
+
+        assert!(
+            started_at.elapsed() >= Duration::from_millis(50),
+            "cancel_and_wait_active_turn returned before turn task finished"
+        );
+        assert!(active_turn_slot.lock().await.is_none());
     }
 }

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::path::{Component, Path};
 use std::sync::Arc;
 use std::sync::{Mutex, MutexGuard};
 
@@ -950,9 +951,28 @@ fn normalize_session_id(session_id: &str) -> anyhow::Result<String> {
     if normalized.is_empty() {
         anyhow::bail!("session_id cannot be empty");
     }
+    if normalized.len() > 128 {
+        anyhow::bail!("session_id is too long (max 128 chars)");
+    }
     if normalized.contains('/') || normalized.contains('\\') {
         anyhow::bail!("session_id cannot contain path separators");
     }
+    if normalized == "." || normalized == ".." {
+        anyhow::bail!("session_id cannot be dot segments");
+    }
+    if !normalized
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        anyhow::bail!("session_id contains invalid characters");
+    }
+
+    let mut components = Path::new(normalized).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => {}
+        _ => anyhow::bail!("session_id must be a single path segment"),
+    }
+
     Ok(normalized.to_string())
 }
 
@@ -1042,7 +1062,12 @@ mod tests {
     fn normalize_session_id_rejects_invalid_session_id() {
         assert!(normalize_session_id("").is_err());
         assert!(normalize_session_id("   ").is_err());
+        assert!(normalize_session_id(".").is_err());
+        assert!(normalize_session_id("..").is_err());
         assert!(normalize_session_id("a/b").is_err());
         assert!(normalize_session_id("a\\b").is_err());
+        assert!(normalize_session_id("a:b").is_err());
+        assert!(normalize_session_id("a b").is_err());
+        assert!(normalize_session_id(&"a".repeat(129)).is_err());
     }
 }

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -779,11 +779,18 @@ impl WsServerState {
 
     async fn create_rpc(&self, session_id: &str) -> anyhow::Result<WireRpcState> {
         let options = &self.options;
-        let session = match Session::find(options.work_dir.clone(), session_id).await {
+        let found_session = Session::find(options.work_dir.clone(), session_id).await;
+        let created_new_session = found_session.is_none();
+        let session = match found_session {
             Some(session) => session,
             None => {
                 Session::create(options.work_dir.clone(), Some(session_id.to_string()), None).await
             }
+        };
+        let rollback_session = if created_new_session {
+            Some(session.clone())
+        } else {
+            None
         };
 
         let cli = KimiCLI::create(
@@ -801,7 +808,22 @@ impl WsServerState {
                 max_ralph_iterations: options.max_ralph_iterations,
             },
         )
-        .await?;
+        .await;
+        let cli = match cli {
+            Ok(cli) => cli,
+            Err(err) => {
+                if let Some(rollback_session) = rollback_session
+                    && let Err(post_run_err) = post_run_session(&rollback_session).await
+                {
+                    warn!(
+                        session_id = %session_id,
+                        "Failed to rollback newly created session after runtime init failure: {}",
+                        post_run_err
+                    );
+                }
+                return Err(err);
+            }
+        };
 
         Ok(WireRpcState::new(cli.soul()))
     }
@@ -825,38 +847,68 @@ async fn ws_upgrade_handler(
             .into_response();
     }
 
+    let prepared_rpc = match state.create_rpc(&session_id).await {
+        Ok(rpc) => rpc,
+        Err(err) => {
+            error!(
+                session_id = %session_id,
+                "Failed to initialize wire websocket runtime: {}",
+                err
+            );
+            state.release_session(&session_id);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("failed to initialize websocket runtime: {err}"),
+            )
+                .into_response();
+        }
+    };
+
+    let rpc_slot = Arc::new(tokio::sync::Mutex::new(Some(prepared_rpc)));
     let state_for_upgrade = Arc::clone(&state);
     let session_id_for_upgrade = session_id.clone();
+    let rpc_slot_for_upgrade = Arc::clone(&rpc_slot);
     let state_for_failed_upgrade = Arc::clone(&state);
     let session_id_for_failed_upgrade = session_id.clone();
+    let rpc_slot_for_failed_upgrade = Arc::clone(&rpc_slot);
     ws.on_failed_upgrade(move |err| {
         warn!(
             session_id = %session_id_for_failed_upgrade,
             "Wire websocket upgrade failed: {}",
             err
         );
-        state_for_failed_upgrade.release_session(&session_id_for_failed_upgrade);
+        tokio::spawn(async move {
+            if let Some(rpc) = rpc_slot_for_failed_upgrade.lock().await.take() {
+                let session = rpc.session();
+                rpc.shutdown().await;
+                if let Err(post_run_err) = post_run_session(&session).await {
+                    warn!(
+                        session_id = %session_id_for_failed_upgrade,
+                        "Failed to finalize session metadata after failed websocket upgrade: {}",
+                        post_run_err
+                    );
+                }
+            }
+            state_for_failed_upgrade.release_session(&session_id_for_failed_upgrade);
+        });
     })
     .on_upgrade(move |socket| async move {
-        handle_ws_socket(socket, state_for_upgrade, session_id_for_upgrade).await;
+        let rpc = rpc_slot_for_upgrade
+            .lock()
+            .await
+            .take()
+            .expect("prepared websocket runtime missing");
+        handle_ws_socket(socket, state_for_upgrade, session_id_for_upgrade, rpc).await;
     })
     .into_response()
 }
 
-async fn handle_ws_socket(socket: WebSocket, state: Arc<WsServerState>, session_id: String) {
-    let rpc = match state.create_rpc(&session_id).await {
-        Ok(rpc) => rpc,
-        Err(err) => {
-            error!(
-                session_id = %session_id,
-                "Failed to create wire session runtime: {}",
-                err
-            );
-            state.release_session(&session_id);
-            return;
-        }
-    };
-
+async fn handle_ws_socket(
+    socket: WebSocket,
+    state: Arc<WsServerState>,
+    session_id: String,
+    rpc: WireRpcState,
+) {
     let (mut sender, mut receiver) = socket.split();
 
     let write_queue = rpc.write_queue();

--- a/kimi-agent/tests/wire_ws.rs
+++ b/kimi-agent/tests/wire_ws.rs
@@ -10,10 +10,8 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::error::Error as WsError;
 
 use kaos::KaosPath;
-use kimi_agent::app::{ConfigInput, CreateOptions, KimiCLI};
 use kimi_agent::config::{Config, LLMModel, LLMProvider, ProviderType, get_default_config};
 use kimi_agent::constant::{NAME, VERSION};
-use kimi_agent::session::Session;
 use kimi_agent::wire::protocol::WIRE_PROTOCOL_VERSION;
 use kimi_agent::wire::server::{WireWsServer, WsSessionRuntimeOptions};
 
@@ -159,37 +157,6 @@ async fn recv_response_by_id(
     panic!("timed out waiting for response id={id}");
 }
 
-async fn create_scripted_cli(
-    scripts: &[&str],
-    home_dir: &TempDir,
-    work_dir: &TempDir,
-) -> (KimiCLI, Vec<EnvGuard>) {
-    let env = configure_scripted_env(home_dir, scripts);
-    let config = scripted_config();
-
-    let work_path = KaosPath::from(work_dir.path().to_path_buf());
-    let session = Session::create(work_path, None, None).await;
-    let cli = KimiCLI::create(
-        session,
-        CreateOptions {
-            config: Some(ConfigInput::Inline(Box::new(config))),
-            model_name: None,
-            thinking: Some(false),
-            yolo: true,
-            agent_file: None,
-            mcp_configs: vec![],
-            skills_dir: None,
-            max_steps_per_turn: None,
-            max_retries_per_step: None,
-            max_ralph_iterations: None,
-        },
-    )
-    .await
-    .expect("create kimi cli");
-
-    (cli, env)
-}
-
 fn scripted_runtime_options(
     work_dir: &TempDir,
     default_session_id: &str,
@@ -215,13 +182,14 @@ async fn test_wire_ws_initialize_and_prompt() {
     let _lock = ENV_LOCK.lock().await;
     let home_dir = TempDir::new().expect("home dir");
     let work_dir = TempDir::new().expect("work dir");
-    let (cli, _env) = create_scripted_cli(&["text: hello from ws"], &home_dir, &work_dir).await;
+    let _env = configure_scripted_env(&home_dir, &["text: hello from ws"]);
+    let options = scripted_runtime_options(&work_dir, "default-session");
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");
     let listen_addr = listener.local_addr().expect("listener local addr");
-    let server = WireWsServer::new(cli.soul(), listen_addr, "/wire").expect("wire ws server");
+    let server = WireWsServer::new(options, listen_addr, "/wire").expect("wire ws server");
     let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
 
     let mut ws = connect_ws_with_retry(&format!("ws://{listen_addr}/wire")).await;
@@ -316,21 +284,20 @@ async fn test_wire_ws_external_tool_request_roundtrip() {
     let _lock = ENV_LOCK.lock().await;
     let home_dir = TempDir::new().expect("home dir");
     let work_dir = TempDir::new().expect("work dir");
-    let (cli, _env) = create_scripted_cli(
+    let _env = configure_scripted_env(
+        &home_dir,
         &[
             r#"tool_call: {"id":"tc-1","name":"open_in_ide","arguments":"{\"path\":\"/tmp/a\"}"}"#,
             "text: tool handled",
         ],
-        &home_dir,
-        &work_dir,
-    )
-    .await;
+    );
+    let options = scripted_runtime_options(&work_dir, "default-session");
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");
     let listen_addr = listener.local_addr().expect("listener local addr");
-    let server = WireWsServer::new(cli.soul(), listen_addr, "/wire").expect("wire ws server");
+    let server = WireWsServer::new(options, listen_addr, "/wire").expect("wire ws server");
     let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
 
     let mut ws = connect_ws_with_retry(&format!("ws://{listen_addr}/wire")).await;
@@ -468,8 +435,7 @@ async fn test_wire_ws_same_session_rejects_second_client() {
         .await
         .expect("bind listener");
     let listen_addr = listener.local_addr().expect("listener local addr");
-    let server =
-        WireWsServer::new_multi(options, listen_addr, "/wire").expect("wire ws multi server");
+    let server = WireWsServer::new(options, listen_addr, "/wire").expect("wire ws multi server");
     let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
 
     let mut first = connect_ws_with_retry(&format!("ws://{listen_addr}/wire?session_id=s1")).await;
@@ -512,8 +478,7 @@ async fn test_wire_ws_allows_parallel_sessions() {
         .await
         .expect("bind listener");
     let listen_addr = listener.local_addr().expect("listener local addr");
-    let server =
-        WireWsServer::new_multi(options, listen_addr, "/wire").expect("wire ws multi server");
+    let server = WireWsServer::new(options, listen_addr, "/wire").expect("wire ws multi server");
     let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
 
     let mut ws_a = connect_ws_with_retry(&format!("ws://{listen_addr}/wire?session_id=s-a")).await;

--- a/kimi-agent/tests/wire_ws.rs
+++ b/kimi-agent/tests/wire_ws.rs
@@ -12,6 +12,7 @@ use tokio_tungstenite::tungstenite::error::Error as WsError;
 use kaos::KaosPath;
 use kimi_agent::config::{Config, LLMModel, LLMProvider, ProviderType, get_default_config};
 use kimi_agent::constant::{NAME, VERSION};
+use kimi_agent::session::Session;
 use kimi_agent::wire::protocol::WIRE_PROTOCOL_VERSION;
 use kimi_agent::wire::server::{WireWsServer, WsSessionRuntimeOptions};
 
@@ -570,6 +571,51 @@ async fn test_wire_ws_allows_parallel_sessions() {
 
     ws_a.close(None).await.expect("close ws a");
     ws_b.close(None).await.expect("close ws b");
+    server_task.abort();
+    let join_err = server_task
+        .await
+        .expect_err("server task should be aborted for test shutdown");
+    assert!(join_err.is_cancelled(), "unexpected join error: {join_err}");
+}
+
+#[tokio::test]
+async fn test_wire_ws_rejects_upgrade_when_runtime_init_fails_and_rolls_back_session() {
+    let _lock = ENV_LOCK.lock().await;
+    let home_dir = TempDir::new().expect("home dir");
+    let work_dir = TempDir::new().expect("work dir");
+    let _env = configure_scripted_env(&home_dir, &["text: hello"]);
+
+    let mut options = scripted_runtime_options(&work_dir, "default-session");
+    options.agent_file = Some(home_dir.path().join("missing-agent.yaml"));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let listen_addr = listener.local_addr().expect("listener local addr");
+    let server = WireWsServer::new(options, listen_addr, "/wire").expect("wire ws server");
+    let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
+
+    let failed_session_id = "failed-session";
+    let connect_result = connect_async(format!(
+        "ws://{listen_addr}/wire?session_id={failed_session_id}"
+    ))
+    .await;
+    match connect_result {
+        Err(WsError::Http(resp)) => {
+            assert_eq!(
+                resp.status(),
+                tokio_tungstenite::tungstenite::http::StatusCode::INTERNAL_SERVER_ERROR
+            );
+        }
+        other => panic!("expected HTTP 500 when runtime init fails, got: {other:?}"),
+    }
+
+    let work_path = KaosPath::from(work_dir.path().to_path_buf());
+    let session = Session::find(work_path, failed_session_id).await;
+    assert!(
+        session.is_none(),
+        "expected failed websocket runtime init to roll back new session"
+    );
+
     server_task.abort();
     let join_err = server_task
         .await

--- a/kimi-agent/tests/wire_ws.rs
+++ b/kimi-agent/tests/wire_ws.rs
@@ -7,14 +7,15 @@ use tempfile::TempDir;
 use tokio::sync::Mutex;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::error::Error as WsError;
 
 use kaos::KaosPath;
 use kimi_agent::app::{ConfigInput, CreateOptions, KimiCLI};
-use kimi_agent::config::{LLMModel, LLMProvider, ProviderType, get_default_config};
+use kimi_agent::config::{Config, LLMModel, LLMProvider, ProviderType, get_default_config};
 use kimi_agent::constant::{NAME, VERSION};
 use kimi_agent::session::Session;
 use kimi_agent::wire::protocol::WIRE_PROTOCOL_VERSION;
-use kimi_agent::wire::server::WireWsServer;
+use kimi_agent::wire::server::{WireWsServer, WsSessionRuntimeOptions};
 
 static ENV_LOCK: Mutex<()> = Mutex::const_new(());
 
@@ -62,6 +63,47 @@ fn set_home_env(path: &Path) -> Vec<EnvGuard> {
     ]
 }
 
+fn scripted_config() -> Config {
+    let mut config = get_default_config();
+    config.default_model = "scripted".to_string();
+    config.models.insert(
+        "scripted".to_string(),
+        LLMModel {
+            provider: "scripted_provider".to_string(),
+            model: "scripted_echo".to_string(),
+            max_context_size: 100_000,
+            capabilities: None,
+        },
+    );
+    config.providers.insert(
+        "scripted_provider".to_string(),
+        LLMProvider {
+            provider_type: ProviderType::ScriptedEcho,
+            base_url: String::new(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        },
+    );
+    config
+}
+
+fn configure_scripted_env(home_dir: &TempDir, scripts: &[&str]) -> Vec<EnvGuard> {
+    let mut env = set_home_env(home_dir.path());
+    let scripts_path = home_dir.path().join("scripts.json");
+    let scripts_json: Vec<String> = scripts.iter().map(|script| script.to_string()).collect();
+    std::fs::write(
+        &scripts_path,
+        serde_json::to_string(&scripts_json).expect("serialize scripts"),
+    )
+    .expect("write scripted echo file");
+    env.push(EnvGuard::set(
+        "KIMI_SCRIPTED_ECHO_SCRIPTS",
+        scripts_path.to_str().expect("scripts path"),
+    ));
+    env
+}
+
 async fn connect_ws_with_retry(
     url: &str,
 ) -> tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>> {
@@ -102,45 +144,28 @@ async fn recv_json(
     }
 }
 
+async fn recv_response_by_id(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    id: &str,
+) -> Value {
+    for _ in 0..200 {
+        let msg = recv_json(ws).await;
+        if msg.get("id").and_then(Value::as_str) == Some(id) {
+            return msg;
+        }
+    }
+    panic!("timed out waiting for response id={id}");
+}
+
 async fn create_scripted_cli(
     scripts: &[&str],
     home_dir: &TempDir,
     work_dir: &TempDir,
 ) -> (KimiCLI, Vec<EnvGuard>) {
-    let mut env = set_home_env(home_dir.path());
-    let scripts_path = home_dir.path().join("scripts.json");
-    let scripts_json: Vec<String> = scripts.iter().map(|script| script.to_string()).collect();
-    std::fs::write(
-        &scripts_path,
-        serde_json::to_string(&scripts_json).expect("serialize scripts"),
-    )
-    .expect("write scripted echo file");
-    env.push(EnvGuard::set(
-        "KIMI_SCRIPTED_ECHO_SCRIPTS",
-        scripts_path.to_str().expect("scripts path"),
-    ));
-
-    let mut config = get_default_config();
-    config.default_model = "scripted".to_string();
-    config.models.insert(
-        "scripted".to_string(),
-        LLMModel {
-            provider: "scripted_provider".to_string(),
-            model: "scripted_echo".to_string(),
-            max_context_size: 100_000,
-            capabilities: None,
-        },
-    );
-    config.providers.insert(
-        "scripted_provider".to_string(),
-        LLMProvider {
-            provider_type: ProviderType::ScriptedEcho,
-            base_url: String::new(),
-            api_key: String::new(),
-            env: None,
-            custom_headers: None,
-        },
-    );
+    let env = configure_scripted_env(home_dir, scripts);
+    let config = scripted_config();
 
     let work_path = KaosPath::from(work_dir.path().to_path_buf());
     let session = Session::create(work_path, None, None).await;
@@ -163,6 +188,26 @@ async fn create_scripted_cli(
     .expect("create kimi cli");
 
     (cli, env)
+}
+
+fn scripted_runtime_options(
+    work_dir: &TempDir,
+    default_session_id: &str,
+) -> WsSessionRuntimeOptions {
+    WsSessionRuntimeOptions {
+        work_dir: KaosPath::from(work_dir.path().to_path_buf()),
+        default_session_id: default_session_id.to_string(),
+        config: scripted_config(),
+        model_name: None,
+        thinking: Some(false),
+        yolo: true,
+        agent_file: None,
+        mcp_configs: vec![],
+        skills_dir: None,
+        max_steps_per_turn: None,
+        max_retries_per_step: None,
+        max_ralph_iterations: None,
+    }
 }
 
 #[tokio::test]
@@ -259,14 +304,11 @@ async fn test_wire_ws_initialize_and_prompt() {
     );
 
     ws.close(None).await.expect("close ws");
-    let server_result = tokio::time::timeout(Duration::from_secs(10), server_task)
+    server_task.abort();
+    let join_err = server_task
         .await
-        .expect("server task timeout")
-        .expect("server task join");
-    assert!(
-        server_result.is_ok(),
-        "server returned error: {server_result:?}"
-    );
+        .expect_err("server task should be aborted for test shutdown");
+    assert!(join_err.is_cancelled(), "unexpected join error: {join_err}");
 }
 
 #[tokio::test]
@@ -407,12 +449,165 @@ async fn test_wire_ws_external_tool_request_roundtrip() {
     );
 
     ws.close(None).await.expect("close ws");
-    let server_result = tokio::time::timeout(Duration::from_secs(10), server_task)
+    server_task.abort();
+    let join_err = server_task
         .await
-        .expect("server task timeout")
-        .expect("server task join");
-    assert!(
-        server_result.is_ok(),
-        "server returned error: {server_result:?}"
+        .expect_err("server task should be aborted for test shutdown");
+    assert!(join_err.is_cancelled(), "unexpected join error: {join_err}");
+}
+
+#[tokio::test]
+async fn test_wire_ws_same_session_rejects_second_client() {
+    let _lock = ENV_LOCK.lock().await;
+    let home_dir = TempDir::new().expect("home dir");
+    let work_dir = TempDir::new().expect("work dir");
+    let _env = configure_scripted_env(&home_dir, &["text: hello"]);
+
+    let options = scripted_runtime_options(&work_dir, "default-session");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let listen_addr = listener.local_addr().expect("listener local addr");
+    let server =
+        WireWsServer::new_multi(options, listen_addr, "/wire").expect("wire ws multi server");
+    let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
+
+    let mut first = connect_ws_with_retry(&format!("ws://{listen_addr}/wire?session_id=s1")).await;
+    let second = connect_async(format!("ws://{listen_addr}/wire?session_id=s1")).await;
+    match second {
+        Err(WsError::Http(resp)) => {
+            assert_eq!(
+                resp.status(),
+                tokio_tungstenite::tungstenite::http::StatusCode::CONFLICT
+            );
+        }
+        other => panic!("expected HTTP 409 for second same-session client, got: {other:?}"),
+    }
+
+    first.close(None).await.expect("close first ws");
+    server_task.abort();
+    let join_err = server_task
+        .await
+        .expect_err("server task should be aborted for test shutdown");
+    assert!(join_err.is_cancelled(), "unexpected join error: {join_err}");
+}
+
+#[tokio::test]
+async fn test_wire_ws_allows_parallel_sessions() {
+    let _lock = ENV_LOCK.lock().await;
+    let home_dir = TempDir::new().expect("home dir");
+    let work_dir = TempDir::new().expect("work dir");
+    let _env = configure_scripted_env(
+        &home_dir,
+        &[
+            "text: session a response",
+            "text: session b response",
+            "text: fallback a",
+            "text: fallback b",
+        ],
     );
+
+    let options = scripted_runtime_options(&work_dir, "default-session");
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind listener");
+    let listen_addr = listener.local_addr().expect("listener local addr");
+    let server =
+        WireWsServer::new_multi(options, listen_addr, "/wire").expect("wire ws multi server");
+    let server_task = tokio::spawn(async move { server.serve_with_listener(listener).await });
+
+    let mut ws_a = connect_ws_with_retry(&format!("ws://{listen_addr}/wire?session_id=s-a")).await;
+    let mut ws_b = connect_ws_with_retry(&format!("ws://{listen_addr}/wire?session_id=s-b")).await;
+
+    ws_a.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-a",
+            "method": "initialize",
+            "params": { "protocol_version": WIRE_PROTOCOL_VERSION }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send initialize a");
+    ws_b.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "init-b",
+            "method": "initialize",
+            "params": { "protocol_version": WIRE_PROTOCOL_VERSION }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send initialize b");
+
+    let init_a = recv_response_by_id(&mut ws_a, "init-a").await;
+    let init_b = recv_response_by_id(&mut ws_b, "init-b").await;
+    assert_eq!(
+        init_a
+            .get("result")
+            .and_then(|v| v.get("protocol_version"))
+            .and_then(Value::as_str),
+        Some(WIRE_PROTOCOL_VERSION)
+    );
+    assert_eq!(
+        init_b
+            .get("result")
+            .and_then(|v| v.get("protocol_version"))
+            .and_then(Value::as_str),
+        Some(WIRE_PROTOCOL_VERSION)
+    );
+
+    ws_a.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "prompt-a",
+            "method": "prompt",
+            "params": { "user_input": "hello a" }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send prompt a");
+    ws_b.send(Message::Text(
+        json!({
+            "jsonrpc": "2.0",
+            "id": "prompt-b",
+            "method": "prompt",
+            "params": { "user_input": "hello b" }
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .expect("send prompt b");
+
+    let resp_a = recv_response_by_id(&mut ws_a, "prompt-a").await;
+    let resp_b = recv_response_by_id(&mut ws_b, "prompt-b").await;
+    assert_eq!(
+        resp_a
+            .get("result")
+            .and_then(|v| v.get("status"))
+            .and_then(Value::as_str),
+        Some("finished")
+    );
+    assert_eq!(
+        resp_b
+            .get("result")
+            .and_then(|v| v.get("status"))
+            .and_then(Value::as_str),
+        Some("finished")
+    );
+
+    ws_a.close(None).await.expect("close ws a");
+    ws_b.close(None).await.expect("close ws b");
+    server_task.abort();
+    let join_err = server_task
+        .await
+        .expect_err("server task should be aborted for test shutdown");
+    assert!(join_err.is_cancelled(), "unexpected join error: {join_err}");
 }


### PR DESCRIPTION
## Summary
- add websocket multi-session runtime via `session_id` query routing
- keep wire JSON-RPC payloads unchanged (`initialize` / `prompt` / `cancel` / `event` / `request`)
- allow parallel websocket clients across different sessions while enforcing single active client per session
- keep websocket server alive after client disconnects
- centralize session finalization with shared `post_run` flow

## Security hardening
- harden `session_id` validation for websocket mode:
  - reject dot segments (`.` / `..`)
  - require a single safe path segment
  - restrict characters to `[A-Za-z0-9._-]`
  - enforce max length 128

## Validation
- `cargo test -p kimi-agent wire_ws -- --nocapture`
- `cargo test -p kimi-agent`
- `cargo clippy --workspace --all-targets`
