### PR TITLE
refactor(llm): use provider-local env overlay for Vertex/ScriptedEcho

### DIFF
--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -168,7 +168,7 @@ pub async fn create_llm(
         ProviderType::OpenaiLegacy => {
             let mut openai = kosong::chat_provider::openai_legacy::OpenAILegacy::new(
                 model.model.clone(),
-                Some(provider.api_key.clone()),
+                non_empty_provider_value(&provider.api_key),
                 Some(provider.base_url.clone()),
                 Some(default_headers.clone()),
             )
@@ -242,7 +242,7 @@ pub async fn create_llm(
             Box::new(
                 kosong::chat_provider::openai_legacy::OpenAILegacy::new(
                     model.model.clone(),
-                    Some(provider.api_key.clone()),
+                    non_empty_provider_value(&provider.api_key),
                     Some(provider.base_url.clone()),
                     Some(default_headers.clone()),
                 )
@@ -252,8 +252,11 @@ pub async fn create_llm(
         }
         ProviderType::Vertexai => {
             // Intentional: use Vertex AI OpenAI-compatible endpoint via OpenAILegacy for now.
-            let api_key =
-                resolve_provider_value(&provider.api_key, provider.env.as_ref(), "OPENAI_API_KEY");
+            let api_key = resolve_provider_value_with_explicit_env(
+                &provider.api_key,
+                provider.env.as_ref(),
+                "OPENAI_API_KEY",
+            );
             let base_url = resolve_provider_value(
                 &provider.base_url,
                 provider.env.as_ref(),
@@ -262,7 +265,7 @@ pub async fn create_llm(
             Box::new(
                 kosong::chat_provider::openai_legacy::OpenAILegacy::new(
                     model.model.clone(),
-                    Some(api_key),
+                    api_key,
                     Some(base_url),
                     Some(default_headers.clone()),
                 )
@@ -375,6 +378,14 @@ fn read_env_var(provider_env: Option<&HashMap<String, String>>, key: &str) -> Op
         .or_else(|| env::var(key).ok())
 }
 
+fn non_empty_provider_value(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
 fn resolve_provider_value(
     value: &str,
     provider_env: Option<&HashMap<String, String>>,
@@ -384,6 +395,17 @@ fn resolve_provider_value(
         return value.to_string();
     }
     read_env_var(provider_env, env_key).unwrap_or_default()
+}
+
+fn resolve_provider_value_with_explicit_env(
+    value: &str,
+    provider_env: Option<&HashMap<String, String>>,
+    env_key: &str,
+) -> Option<String> {
+    if !value.is_empty() {
+        return Some(value.to_string());
+    }
+    provider_env.and_then(|envs| envs.get(env_key)).cloned()
 }
 
 async fn load_scripted_echo_scripts(

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -252,11 +252,18 @@ pub async fn create_llm(
         }
         ProviderType::Vertexai => {
             // Intentional: use Vertex AI OpenAI-compatible endpoint via OpenAILegacy for now.
+            let api_key =
+                resolve_provider_value(&provider.api_key, provider.env.as_ref(), "OPENAI_API_KEY");
+            let base_url = resolve_provider_value(
+                &provider.base_url,
+                provider.env.as_ref(),
+                "OPENAI_BASE_URL",
+            );
             Box::new(
                 kosong::chat_provider::openai_legacy::OpenAILegacy::new(
                     model.model.clone(),
-                    Some(provider.api_key.clone()),
-                    Some(provider.base_url.clone()),
+                    Some(api_key),
+                    Some(base_url),
                     Some(default_headers.clone()),
                 )
                 .map_err(map_chat_provider_error)?
@@ -366,6 +373,17 @@ fn read_env_var(provider_env: Option<&HashMap<String, String>>, key: &str) -> Op
         .and_then(|envs| envs.get(key))
         .cloned()
         .or_else(|| env::var(key).ok())
+}
+
+fn resolve_provider_value(
+    value: &str,
+    provider_env: Option<&HashMap<String, String>>,
+    env_key: &str,
+) -> String {
+    if !value.is_empty() {
+        return value.to_string();
+    }
+    read_env_var(provider_env, env_key).unwrap_or_default()
 }
 
 async fn load_scripted_echo_scripts(

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -252,14 +252,6 @@ pub async fn create_llm(
         }
         ProviderType::Vertexai => {
             // Intentional: use Vertex AI OpenAI-compatible endpoint via OpenAILegacy for now.
-            if let Some(envs) = &provider.env {
-                for (key, value) in envs {
-                    // SAFETY: matches Python behavior of mutating process env for provider setup.
-                    unsafe {
-                        env::set_var(key, value);
-                    }
-                }
-            }
             Box::new(
                 kosong::chat_provider::openai_legacy::OpenAILegacy::new(
                     model.model.clone(),
@@ -273,16 +265,8 @@ pub async fn create_llm(
         }
         ProviderType::Echo => Box::new(kosong::chat_provider::echo::EchoChatProvider),
         ProviderType::ScriptedEcho => {
-            if let Some(envs) = &provider.env {
-                for (key, value) in envs {
-                    // SAFETY: matches Python behavior of mutating process env for provider setup.
-                    unsafe {
-                        env::set_var(key, value);
-                    }
-                }
-            }
-            let scripts = load_scripted_echo_scripts().await?;
-            let trace = env::var("KIMI_SCRIPTED_ECHO_TRACE")
+            let scripts = load_scripted_echo_scripts(provider.env.as_ref()).await?;
+            let trace = read_env_var(provider.env.as_ref(), "KIMI_SCRIPTED_ECHO_TRACE")
                 .unwrap_or_default()
                 .trim()
                 .to_lowercase();
@@ -377,12 +361,22 @@ fn parse_env_f64(value: &str) -> Result<f64, LLMError> {
         .map_err(|_| LLMError::EnvVar(format!("could not convert string to float: '{}'", value)))
 }
 
-async fn load_scripted_echo_scripts() -> Result<Vec<String>, LLMError> {
-    let script_path = env::var("KIMI_SCRIPTED_ECHO_SCRIPTS").map_err(|_| {
-        LLMError::ScriptedEcho(
-            "KIMI_SCRIPTED_ECHO_SCRIPTS is required for _scripted_echo.".to_string(),
-        )
-    })?;
+fn read_env_var(provider_env: Option<&HashMap<String, String>>, key: &str) -> Option<String> {
+    provider_env
+        .and_then(|envs| envs.get(key))
+        .cloned()
+        .or_else(|| env::var(key).ok())
+}
+
+async fn load_scripted_echo_scripts(
+    provider_env: Option<&HashMap<String, String>>,
+) -> Result<Vec<String>, LLMError> {
+    let script_path =
+        read_env_var(provider_env, "KIMI_SCRIPTED_ECHO_SCRIPTS").ok_or_else(|| {
+            LLMError::ScriptedEcho(
+                "KIMI_SCRIPTED_ECHO_SCRIPTS is required for _scripted_echo.".to_string(),
+            )
+        })?;
     let path = PathBuf::from(script_path).expanduser();
     if tokio::fs::metadata(&path).await.is_err() {
         return Err(LLMError::ScriptedEcho(format!(

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -474,3 +474,62 @@ async fn test_create_llm_vertexai_uses_provider_env_openai_api_key_without_mutat
         "process-old-key"
     );
 }
+
+#[tokio::test]
+async fn test_create_llm_vertexai_explicit_empty_provider_env_api_key_disables_process_env_fallback()
+ {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = EnvGuard::set("OPENAI_API_KEY", "process-old-key");
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("authorization", "Bearer process-old-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .expect(0)
+        .mount(&mock_server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let provider = LLMProvider {
+        provider_type: ProviderType::Vertexai,
+        base_url: format!("{}/v1", mock_server.uri()),
+        api_key: String::new(),
+        env: Some(HashMap::from([(
+            "OPENAI_API_KEY".to_string(),
+            String::new(),
+        )])),
+        custom_headers: None,
+    };
+    let model = LLMModel {
+        provider: "vertex".to_string(),
+        model: "gemini-3-pro-preview".to_string(),
+        max_context_size: 1_000_000,
+        capabilities: None,
+    };
+
+    let llm = create_llm(&provider, &model, None, None)
+        .await
+        .expect("create llm")
+        .expect("llm");
+    assert!(llm.chat_provider.as_any().is::<OpenAILegacy>());
+    assert_eq!(llm.chat_provider.name(), "vertexai");
+
+    let tools: Vec<kosong::tooling::Tool> = vec![];
+    let history: Vec<kosong::message::Message> = vec![];
+    let _stream = llm
+        .chat_provider
+        .generate("", &tools, &history)
+        .await
+        .expect("generate request should not fall back to process openai key");
+
+    assert_eq!(
+        std::env::var("OPENAI_API_KEY").expect("openai env"),
+        "process-old-key"
+    );
+}

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -3,6 +3,8 @@ use std::collections::{HashMap, HashSet};
 use serde_json::json;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use kimi_agent::config::{LLMModel, LLMProvider, ModelCapability, ProviderType};
 use kimi_agent::llm::{augment_provider_with_env_vars, create_llm};
@@ -418,5 +420,57 @@ async fn test_create_llm_scripted_echo_prefers_provider_env_without_mutating_pro
     assert_eq!(
         std::env::var("KIMI_SCRIPTED_ECHO_SCRIPTS").expect("scripted echo env"),
         "/tmp/does-not-exist.json"
+    );
+}
+
+#[tokio::test]
+async fn test_create_llm_vertexai_uses_provider_env_openai_api_key_without_mutating_process_env() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = EnvGuard::set("OPENAI_API_KEY", "process-old-key");
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("authorization", "Bearer overlay-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let provider = LLMProvider {
+        provider_type: ProviderType::Vertexai,
+        base_url: format!("{}/v1", mock_server.uri()),
+        api_key: String::new(),
+        env: Some(HashMap::from([(
+            "OPENAI_API_KEY".to_string(),
+            "overlay-key".to_string(),
+        )])),
+        custom_headers: None,
+    };
+    let model = LLMModel {
+        provider: "vertex".to_string(),
+        model: "gemini-3-pro-preview".to_string(),
+        max_context_size: 1_000_000,
+        capabilities: None,
+    };
+
+    let llm = create_llm(&provider, &model, None, None)
+        .await
+        .expect("create llm")
+        .expect("llm");
+    assert!(llm.chat_provider.as_any().is::<OpenAILegacy>());
+    assert_eq!(llm.chat_provider.name(), "vertexai");
+
+    let tools: Vec<kosong::tooling::Tool> = vec![];
+    let history: Vec<kosong::message::Message> = vec![];
+    let _stream = llm
+        .chat_provider
+        .generate("", &tools, &history)
+        .await
+        .expect("generate request should use provider env api key");
+
+    assert_eq!(
+        std::env::var("OPENAI_API_KEY").expect("openai env"),
+        "process-old-key"
     );
 }

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use serde_json::json;
+use tempfile::TempDir;
 use tokio::sync::Mutex;
 
 use kimi_agent::config::{LLMModel, LLMProvider, ModelCapability, ProviderType};
@@ -345,7 +346,7 @@ async fn test_create_llm_google_genai_provider_uses_openai_compat() {
 }
 
 #[tokio::test]
-async fn test_create_llm_vertexai_provider_sets_env_and_uses_openai_compat() {
+async fn test_create_llm_vertexai_provider_does_not_mutate_process_env_and_uses_openai_compat() {
     let _lock = ENV_LOCK.lock().await;
     let _guard = EnvGuard::set("VERTEX_TEST_PROJECT", "old");
 
@@ -375,6 +376,47 @@ async fn test_create_llm_vertexai_provider_sets_env_and_uses_openai_compat() {
     assert_eq!(llm.chat_provider.name(), "vertexai");
     assert_eq!(
         std::env::var("VERTEX_TEST_PROJECT").expect("vertex env"),
-        "new-project"
+        "old"
+    );
+}
+
+#[tokio::test]
+async fn test_create_llm_scripted_echo_prefers_provider_env_without_mutating_process_env() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = EnvGuard::set("KIMI_SCRIPTED_ECHO_SCRIPTS", "/tmp/does-not-exist.json");
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let scripts_path = temp_dir.path().join("scripts.json");
+    std::fs::write(&scripts_path, r#"["text: from provider env"]"#).expect("write scripts");
+
+    let provider = LLMProvider {
+        provider_type: ProviderType::ScriptedEcho,
+        base_url: String::new(),
+        api_key: String::new(),
+        env: Some(HashMap::from([
+            (
+                "KIMI_SCRIPTED_ECHO_SCRIPTS".to_string(),
+                scripts_path.to_string_lossy().to_string(),
+            ),
+            ("KIMI_SCRIPTED_ECHO_TRACE".to_string(), "false".to_string()),
+        ])),
+        custom_headers: None,
+    };
+    let model = LLMModel {
+        provider: "_scripted_echo".to_string(),
+        model: "scripted_echo".to_string(),
+        max_context_size: 10_000,
+        capabilities: None,
+    };
+
+    let llm = create_llm(&provider, &model, None, None)
+        .await
+        .expect("create llm")
+        .expect("llm");
+
+    assert_eq!(llm.chat_provider.name(), "scripted_echo");
+    assert_eq!(
+        std::env::var("KIMI_SCRIPTED_ECHO_SCRIPTS").expect("scripted echo env"),
+        "/tmp/does-not-exist.json"
     );
 }

--- a/kosong/src/chat_provider/openai_legacy.rs
+++ b/kosong/src/chat_provider/openai_legacy.rs
@@ -43,10 +43,10 @@ impl OpenAILegacy {
         base_url: Option<String>,
         default_headers: Option<HeaderMap>,
     ) -> Result<Self, ChatProviderError> {
-        let api_key = api_key
-            .filter(|value| !value.is_empty())
-            .or_else(|| env::var("OPENAI_API_KEY").ok())
-            .unwrap_or_default();
+        let api_key = match api_key {
+            Some(value) => value,
+            None => env::var("OPENAI_API_KEY").unwrap_or_default(),
+        };
         let mut base_url = base_url
             .filter(|value| !value.is_empty())
             .or_else(|| env::var("OPENAI_BASE_URL").ok())


### PR DESCRIPTION
## Summary
- remove global process env mutation (`set_var`) from VertexAI and ScriptedEcho provider initialization
- add provider-local env overlay resolution for ScriptedEcho and VertexAI
- preserve explicit empty API-key override semantics for VertexAI (`OPENAI_API_KEY = ""` disables fallback)

## Why
- fix concurrency/safety risk from global env mutation in websocket multi-session runtime init
- restore VertexAI env-driven auth behavior without relying on process-global side effects
- avoid accidental Authorization header leakage when env explicitly clears API key

## Verification
- `cargo fmt`
- `cargo test -p kimi-agent test_create_llm_vertexai -- --nocapture`
- `cargo test -p kimi-agent wire_ws -- --nocapture`
- `cargo test -p kimi-agent`
- `cargo clippy --workspace --all-targets`
