### PR TITLE
Add skill-scoped MCP lazy loading and session cleanup

### DIFF
--- a/kimi-agent/src/skill/AGENTS.md
+++ b/kimi-agent/src/skill/AGENTS.md
@@ -11,3 +11,4 @@
 - Skills are discovered from layered roots (builtin → user → project) with later roots overriding.
 - Flow skills require a `mermaid` or `d2` fenced code block in `SKILL.md`.
 - Invalid flow parsing falls back to `standard` skill type.
+- Skill frontmatter may include `mcp` server definitions (`stdio`/`http`) for runtime dynamic loading.

--- a/kimi-agent/src/skill/mod.rs
+++ b/kimi-agent/src/skill/mod.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use kaos::{KaosPath, get_current_kaos};
+use serde::Deserialize;
 use serde_yaml::Value;
 use tracing::{error, info, warn};
 
@@ -18,6 +19,85 @@ pub enum SkillType {
     Flow,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SkillMcpServer {
+    Stdio(SkillMcpStdioServer),
+    Http(SkillMcpHttpServer),
+}
+
+impl SkillMcpServer {
+    pub fn name(&self) -> &str {
+        match self {
+            SkillMcpServer::Stdio(server) => &server.name,
+            SkillMcpServer::Http(server) => &server.name,
+        }
+    }
+
+    pub fn scoped_name(&self, skill_name: &str) -> String {
+        format!(
+            "skill::{}::{}",
+            normalize_skill_name(skill_name),
+            normalize_skill_name(self.name())
+        )
+    }
+
+    pub fn to_mcp_config_entry(&self) -> serde_json::Value {
+        match self {
+            SkillMcpServer::Stdio(server) => serde_json::json!({
+                "command": server.command,
+                "args": server.args,
+                "env": server.env,
+            }),
+            SkillMcpServer::Http(server) => serde_json::json!({
+                "url": server.url,
+                "transport": server.transport,
+                "headers": server.headers,
+                "auth": server.auth,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillMcpStdioServer {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SkillMcpHttpServer {
+    pub name: String,
+    pub url: String,
+    pub transport: Option<String>,
+    pub headers: Option<HashMap<String, String>>,
+    pub auth: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum SkillMcpServerRaw {
+    Stdio {
+        name: String,
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default)]
+        env: Option<HashMap<String, String>>,
+    },
+    Http {
+        name: String,
+        url: String,
+        #[serde(default)]
+        transport: Option<String>,
+        #[serde(default)]
+        headers: Option<HashMap<String, String>>,
+        #[serde(default)]
+        auth: Option<String>,
+    },
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Skill {
     pub name: String,
@@ -25,6 +105,7 @@ pub struct Skill {
     pub skill_type: SkillType,
     pub dir: KaosPath,
     pub flow: Option<Flow>,
+    pub mcp_servers: Vec<SkillMcpServer>,
 }
 
 impl Skill {
@@ -192,6 +273,7 @@ pub fn parse_skill_text(content: &str, dir_path: &KaosPath) -> Result<Skill, Str
         .and_then(|map| map.get("type"))
         .and_then(value_as_string)
         .unwrap_or_else(|| "standard".to_string());
+    let mcp_servers = parse_skill_mcp_servers(&frontmatter)?;
 
     let mut flow = None;
     let mut resolved_type = SkillType::Standard;
@@ -215,7 +297,56 @@ pub fn parse_skill_text(content: &str, dir_path: &KaosPath) -> Result<Skill, Str
         skill_type: resolved_type,
         dir: dir_path.clone(),
         flow,
+        mcp_servers,
     })
+}
+
+fn parse_skill_mcp_servers(
+    frontmatter: &Option<HashMap<String, Value>>,
+) -> Result<Vec<SkillMcpServer>, String> {
+    let Some(raw_value) = frontmatter.as_ref().and_then(|map| map.get("mcp")) else {
+        return Ok(Vec::new());
+    };
+    let raw_servers: Vec<SkillMcpServerRaw> = serde_yaml::from_value(raw_value.clone())
+        .map_err(|err| format!("Invalid mcp frontmatter: {err}"))?;
+
+    let mut servers = Vec::new();
+    let mut names = HashSet::new();
+    for raw in raw_servers {
+        let server = match raw {
+            SkillMcpServerRaw::Stdio {
+                name,
+                command,
+                args,
+                env,
+            } => SkillMcpServer::Stdio(SkillMcpStdioServer {
+                name,
+                command,
+                args,
+                env,
+            }),
+            SkillMcpServerRaw::Http {
+                name,
+                url,
+                transport,
+                headers,
+                auth,
+            } => SkillMcpServer::Http(SkillMcpHttpServer {
+                name,
+                url,
+                transport,
+                headers,
+                auth,
+            }),
+        };
+        let normalized_name = normalize_skill_name(server.name());
+        if !names.insert(normalized_name) {
+            return Err(format!("Duplicate mcp server name '{}'.", server.name()));
+        }
+        servers.push(server);
+    }
+
+    Ok(servers)
 }
 
 fn parse_flow_from_skill(content: &str) -> Result<Flow, FlowError> {

--- a/kimi-agent/src/soul/AGENTS.md
+++ b/kimi-agent/src/soul/AGENTS.md
@@ -29,3 +29,4 @@
 - Pending D-Mail triggers a context revert + checkpoint + D-Mail message append on the next loop iteration.
 - Compaction retries use the same backoff rules as step retries.
 - Flow runners warn on extra args and otherwise ignore them.
+- Skill-declared MCP servers are loaded lazily when `/skill:*` or `/flow:*` executes and are cleaned up on wire session shutdown.

--- a/kimi-agent/src/soul/kimisoul.rs
+++ b/kimi-agent/src/soul/kimisoul.rs
@@ -425,7 +425,7 @@ impl KimiSoul {
 
         wire_send(WireMessage::ContentPart(ContentPart::Text(TextPart::new(
             format!(
-                "Failed to load MCP server(s) required by skill `/{}{}:`\n{}",
+                "Failed to load MCP server(s) required by skill `/{}{}`:\n{}",
                 SKILL_COMMAND_PREFIX,
                 skill.name,
                 failures.join("\n")

--- a/kimi-agent/src/soul/kimisoul.rs
+++ b/kimi-agent/src/soul/kimisoul.rs
@@ -238,7 +238,10 @@ impl KimiSoul {
             },
             Some(SlashHandler::Skill(skill)) => self.run_skill(skill, args).await,
             Some(SlashHandler::Flow(skill, runner)) => {
-                if !self.ensure_skill_mcp_ready(skill).await? {
+                if !self
+                    .ensure_skill_mcp_ready(skill, FLOW_COMMAND_PREFIX)
+                    .await?
+                {
                     return Ok(());
                 }
                 runner.run(self, args).await
@@ -340,7 +343,10 @@ impl KimiSoul {
     }
 
     async fn run_skill(&self, skill: &Skill, args: &str) -> anyhow::Result<()> {
-        if !self.ensure_skill_mcp_ready(skill).await? {
+        if !self
+            .ensure_skill_mcp_ready(skill, SKILL_COMMAND_PREFIX)
+            .await?
+        {
             return Ok(());
         }
         let Some(mut skill_text) = read_skill_text(skill).await else {
@@ -365,7 +371,11 @@ impl KimiSoul {
         Ok(())
     }
 
-    async fn ensure_skill_mcp_ready(&self, skill: &Skill) -> anyhow::Result<bool> {
+    async fn ensure_skill_mcp_ready(
+        &self,
+        skill: &Skill,
+        command_prefix: &str,
+    ) -> anyhow::Result<bool> {
         if skill.mcp_servers.is_empty() {
             return Ok(true);
         }
@@ -426,7 +436,7 @@ impl KimiSoul {
         wire_send(WireMessage::ContentPart(ContentPart::Text(TextPart::new(
             format!(
                 "Failed to load MCP server(s) required by skill `/{}{}`:\n{}",
-                SKILL_COMMAND_PREFIX,
+                command_prefix,
                 skill.name,
                 failures.join("\n")
             ),

--- a/kimi-agent/src/soul/kimisoul.rs
+++ b/kimi-agent/src/soul/kimisoul.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,6 +16,7 @@ use crate::config::ModelCapability;
 use crate::skill::flow::{Flow, FlowEdge, FlowLabel, FlowNode, FlowNodeKind, parse_choice};
 use crate::skill::{Skill, SkillType, read_skill_text};
 use crate::soul::agent::{Agent, Runtime};
+use crate::soul::toolset::{McpServerStatus, wait_mcp_loading_tasks};
 use crate::soul::{
     LLMNotSet, LLMNotSupported, MaxStepsReached, Soul, StatusSnapshot,
     approval::Approval,
@@ -70,7 +71,7 @@ pub struct KimiSoul {
 enum SlashHandler {
     Builtin(BuiltinSlash),
     Skill(Skill),
-    Flow(FlowRunner),
+    Flow(Skill, FlowRunner),
 }
 
 #[derive(Clone, Copy)]
@@ -211,7 +212,7 @@ impl KimiSoul {
                 description: skill.description.clone(),
                 aliases: Vec::new(),
             });
-            handlers.insert(name.clone(), SlashHandler::Flow(runner));
+            handlers.insert(name.clone(), SlashHandler::Flow(skill.clone(), runner));
             seen.insert(name);
         }
 
@@ -236,7 +237,12 @@ impl KimiSoul {
                 BuiltinSlash::Yolo => self.slash_yolo().await,
             },
             Some(SlashHandler::Skill(skill)) => self.run_skill(skill, args).await,
-            Some(SlashHandler::Flow(runner)) => runner.run(self, args).await,
+            Some(SlashHandler::Flow(skill, runner)) => {
+                if !self.ensure_skill_mcp_ready(skill).await? {
+                    return Ok(());
+                }
+                runner.run(self, args).await
+            }
             None => {
                 wire_send(WireMessage::ContentPart(ContentPart::Text(TextPart::new(
                     format!("Unknown slash command \"/{}\".", name),
@@ -334,6 +340,9 @@ impl KimiSoul {
     }
 
     async fn run_skill(&self, skill: &Skill, args: &str) -> anyhow::Result<()> {
+        if !self.ensure_skill_mcp_ready(skill).await? {
+            return Ok(());
+        }
         let Some(mut skill_text) = read_skill_text(skill).await else {
             wire_send(WireMessage::ContentPart(ContentPart::Text(TextPart::new(
                 format!(
@@ -356,6 +365,75 @@ impl KimiSoul {
         Ok(())
     }
 
+    async fn ensure_skill_mcp_ready(&self, skill: &Skill) -> anyhow::Result<bool> {
+        if skill.mcp_servers.is_empty() {
+            return Ok(true);
+        }
+
+        let mut mcp_servers = serde_json::Map::new();
+        let mut required_server_names = Vec::new();
+        for server in &skill.mcp_servers {
+            let scoped_name = server.scoped_name(&skill.name);
+            mcp_servers.insert(scoped_name.clone(), server.to_mcp_config_entry());
+            required_server_names.push(scoped_name);
+        }
+        let mcp_config = serde_json::json!({ "mcpServers": mcp_servers });
+
+        let pending_tasks = {
+            let mut toolset = self.agent.toolset.lock().await;
+            toolset
+                .load_mcp_tools(
+                    &[mcp_config],
+                    &self.runtime,
+                    Arc::clone(&self.agent.toolset),
+                )
+                .await?;
+            toolset.take_mcp_loading_tasks()
+        };
+        let _ = wait_mcp_loading_tasks(pending_tasks).await;
+
+        let failures = {
+            let toolset = self.agent.toolset.lock().await;
+            required_server_names
+                .iter()
+                .filter_map(|name| {
+                    let info = toolset.mcp_servers().get(name);
+                    match info {
+                        None => Some(format!("{} (missing): not loaded", name)),
+                        Some(info) => match info.status {
+                            McpServerStatus::Connected => None,
+                            McpServerStatus::Unauthorized
+                            | McpServerStatus::Failed
+                            | McpServerStatus::Pending
+                            | McpServerStatus::Connecting => Some(format!(
+                                "{} ({:?}): {}",
+                                name,
+                                info.status,
+                                info.last_error
+                                    .clone()
+                                    .unwrap_or_else(|| "unknown error".to_string())
+                            )),
+                        },
+                    }
+                })
+                .collect::<Vec<_>>()
+        };
+
+        if failures.is_empty() {
+            return Ok(true);
+        }
+
+        wire_send(WireMessage::ContentPart(ContentPart::Text(TextPart::new(
+            format!(
+                "Failed to load MCP server(s) required by skill `/{}{}:`\n{}",
+                SKILL_COMMAND_PREFIX,
+                skill.name,
+                failures.join("\n")
+            ),
+        ))));
+        Ok(false)
+    }
+
     async fn turn(&self, user_message: Message) -> Result<TurnOutcome, anyhow::Error> {
         let llm = self.runtime.llm.as_ref().ok_or(LLMNotSet)?;
         let missing = check_message(&user_message, &llm.capabilities);
@@ -376,12 +454,12 @@ impl KimiSoul {
     }
 
     async fn agent_loop(&self) -> Result<TurnOutcome, anyhow::Error> {
-        let mcp_task = {
+        let mcp_tasks = {
             let mut toolset = self.agent.toolset.lock().await;
-            toolset.take_mcp_loading_task()
+            toolset.take_mcp_loading_tasks()
         };
-        if let Some(task) = mcp_task {
-            let _ = task.await;
+        if !mcp_tasks.is_empty() {
+            let _ = wait_mcp_loading_tasks(mcp_tasks).await;
         }
 
         let mut step_no = 0;
@@ -690,6 +768,35 @@ impl KimiSoul {
         }
         wire_send(WireMessage::CompactionEnd(CompactionEnd {}));
         Ok(())
+    }
+
+    pub async fn shutdown(&self) {
+        let toolsets = {
+            let mut seen = HashSet::new();
+            let market = self.runtime.labor_market.lock().await;
+            let mut toolsets = Vec::new();
+
+            let mut push_toolset =
+                |toolset: &Arc<tokio::sync::Mutex<crate::soul::toolset::KimiToolset>>| {
+                    let ptr = Arc::as_ptr(toolset) as usize;
+                    if seen.insert(ptr) {
+                        toolsets.push(Arc::clone(toolset));
+                    }
+                };
+
+            push_toolset(&self.agent.toolset);
+            for agent in market.fixed_subagents().values() {
+                push_toolset(&agent.toolset);
+            }
+            for agent in market.dynamic_subagents().values() {
+                push_toolset(&agent.toolset);
+            }
+            toolsets
+        };
+
+        for toolset in toolsets {
+            toolset.lock().await.cleanup().await;
+        }
     }
 }
 

--- a/kimi-agent/src/soul/toolset.rs
+++ b/kimi-agent/src/soul/toolset.rs
@@ -58,7 +58,8 @@ pub struct KimiToolset {
     tools: HashMap<String, Arc<dyn CallableTool>>,
     external_tools: HashSet<String>,
     mcp_servers: HashMap<String, McpServerInfo>,
-    mcp_loading_task: Option<tokio::task::JoinHandle<Result<(), MCPRuntimeError>>>,
+    mcp_loading_tasks: Vec<tokio::task::JoinHandle<Result<(), MCPRuntimeError>>>,
+    mcp_tool_owners: HashMap<String, String>,
 }
 
 impl KimiToolset {
@@ -67,7 +68,8 @@ impl KimiToolset {
             tools: HashMap::new(),
             external_tools: HashSet::new(),
             mcp_servers: HashMap::new(),
-            mcp_loading_task: None,
+            mcp_loading_tasks: Vec::new(),
+            mcp_tool_owners: HashMap::new(),
         }
     }
 
@@ -104,6 +106,34 @@ impl KimiToolset {
         self.add(Arc::new(tool));
         self.external_tools.insert(name.to_string());
         Ok(())
+    }
+
+    fn register_mcp_tool(&mut self, server_name: &str, tool: McpTool) -> bool {
+        let base = tool.base();
+        let name = base.name.clone();
+        let previous_owner = self.mcp_tool_owners.get(&name).cloned();
+
+        if previous_owner.is_none() && self.tools.contains_key(&name) {
+            warn!(
+                "Skipping MCP tool '{}' from server '{}': name conflicts with non-MCP tool",
+                name, server_name
+            );
+            return false;
+        }
+
+        if let Some(owner) = previous_owner
+            && owner != server_name
+        {
+            warn!(
+                "MCP tool '{}' from server '{}' overrides MCP tool from server '{}'",
+                name, server_name, owner
+            );
+        }
+
+        self.tools
+            .insert(name.clone(), Arc::new(tool) as Arc<dyn CallableTool>);
+        self.mcp_tool_owners.insert(name, server_name.to_string());
+        true
     }
 
     pub fn load_tools(
@@ -153,6 +183,22 @@ impl KimiToolset {
                 continue;
             }
             for (name, server) in parsed {
+                if let Some(existing) = self.mcp_servers.get(&name) {
+                    if existing.config != server {
+                        return Err(anyhow::Error::new(MCPConfigError::new(format!(
+                            "Conflicting MCP config for server '{}'",
+                            name
+                        ))));
+                    }
+
+                    match existing.status {
+                        McpServerStatus::Connected
+                        | McpServerStatus::Connecting
+                        | McpServerStatus::Pending => continue,
+                        McpServerStatus::Failed | McpServerStatus::Unauthorized => {}
+                    }
+                }
+
                 if let McpServerConfig::Http(http) = &server
                     && http.auth.as_deref() == Some("oauth")
                 {
@@ -160,10 +206,20 @@ impl KimiToolset {
                         .await
                         .map_err(|err| anyhow::anyhow!("Failed to read MCP auth tokens: {err}"))?;
                     if !authorized {
-                        self.mcp_servers.insert(
-                            name.clone(),
-                            McpServerInfo::new(McpServerStatus::Unauthorized, server.clone()),
-                        );
+                        self.mcp_servers
+                            .entry(name.clone())
+                            .and_modify(|info| {
+                                info.status = McpServerStatus::Unauthorized;
+                                info.last_error = Some("OAuth authorization required".to_string());
+                            })
+                            .or_insert_with(|| {
+                                let mut info = McpServerInfo::new(
+                                    McpServerStatus::Unauthorized,
+                                    server.clone(),
+                                );
+                                info.last_error = Some("OAuth authorization required".to_string());
+                                info
+                            });
                         warn!(
                             "Skipping OAuth MCP server '{}': not authorized. Run 'kimi-agent mcp auth {}' first.",
                             name, name
@@ -175,10 +231,13 @@ impl KimiToolset {
                 if std::env::var("KIMI_TEST_TRACE").as_deref() == Ok("1") {
                     eprintln!("MCP config loaded server: {name}");
                 }
-                self.mcp_servers.insert(
-                    name.clone(),
-                    McpServerInfo::new(McpServerStatus::Pending, server),
-                );
+                self.mcp_servers
+                    .entry(name.clone())
+                    .and_modify(|info| {
+                        info.status = McpServerStatus::Pending;
+                        info.last_error = None;
+                    })
+                    .or_insert_with(|| McpServerInfo::new(McpServerStatus::Pending, server));
                 servers_to_connect.push(name);
             }
         }
@@ -207,21 +266,59 @@ impl KimiToolset {
                 )))
             }
         });
-        self.mcp_loading_task = Some(task);
+        self.mcp_loading_tasks.push(task);
         Ok(())
     }
 
     pub async fn wait_for_mcp_tools(&mut self) -> Result<(), anyhow::Error> {
-        if let Some(task) = self.mcp_loading_task.take() {
-            task.await??;
-        }
-        Ok(())
+        wait_mcp_loading_tasks(self.take_mcp_loading_tasks()).await
     }
 
-    pub fn take_mcp_loading_task(
+    pub fn take_mcp_loading_tasks(
         &mut self,
-    ) -> Option<tokio::task::JoinHandle<Result<(), MCPRuntimeError>>> {
-        self.mcp_loading_task.take()
+    ) -> Vec<tokio::task::JoinHandle<Result<(), MCPRuntimeError>>> {
+        std::mem::take(&mut self.mcp_loading_tasks)
+    }
+
+    pub async fn cleanup(&mut self) {
+        let tasks = self.take_mcp_loading_tasks();
+        for task in tasks {
+            task.abort();
+            let _ = task.await;
+        }
+
+        let mut servers = std::mem::take(&mut self.mcp_servers);
+        for info in servers.values_mut() {
+            if let Some(client) = info.client.take() {
+                let mut service = client.service.lock().await;
+                let _ = service.close().await;
+            }
+        }
+
+        for name in self.mcp_tool_owners.keys().cloned().collect::<Vec<_>>() {
+            self.tools.remove(&name);
+        }
+        self.mcp_tool_owners.clear();
+    }
+}
+
+pub async fn wait_mcp_loading_tasks(
+    tasks: Vec<tokio::task::JoinHandle<Result<(), MCPRuntimeError>>>,
+) -> Result<(), anyhow::Error> {
+    let mut failures = Vec::new();
+    for task in tasks {
+        match task.await {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => failures.push(err.to_string()),
+            Err(err) => failures.push(err.to_string()),
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(
+            "Failed to connect MCP servers: {failures:?}"
+        ))
     }
 }
 
@@ -426,7 +523,7 @@ struct McpConfig {
     mcp_servers: HashMap<String, McpServerConfig>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum McpServerConfig {
     Stdio(StdioServerConfig),
@@ -435,7 +532,7 @@ pub enum McpServerConfig {
 
 pub type McpToolSpec = rmcp::model::Tool;
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct StdioServerConfig {
     command: String,
     #[serde(default)]
@@ -444,7 +541,7 @@ pub struct StdioServerConfig {
     env: Option<HashMap<String, String>>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct HttpServerConfig {
     pub url: String,
     #[serde(default)]
@@ -629,6 +726,8 @@ async fn connect_mcp_server(
     let tools = match client.peer.list_all_tools().await {
         Ok(tools) => tools,
         Err(err) => {
+            let mut service = client.service.lock().await;
+            let _ = service.close().await;
             let mut guard = toolset.lock().await;
             if let Some(info) = guard.mcp_servers.get_mut(server_name) {
                 info.status = McpServerStatus::Failed;
@@ -645,19 +744,39 @@ async fn connect_mcp_server(
     }
 
     let mut guard = toolset.lock().await;
-    let info = guard
-        .mcp_servers
-        .get_mut(server_name)
-        .ok_or_else(|| MCPRuntimeError::new("MCP server not found"))?;
-    info.status = McpServerStatus::Connected;
-    info!("Connected MCP server: {}", server_name);
-    info.tools = tools.iter().map(|tool| tool.name.to_string()).collect();
-    info.last_error = None;
-    info.client = Some(client.clone());
+    let previous_tools = {
+        let info = guard
+            .mcp_servers
+            .get_mut(server_name)
+            .ok_or_else(|| MCPRuntimeError::new("MCP server not found"))?;
+        info.status = McpServerStatus::Connected;
+        info!("Connected MCP server: {}", server_name);
+        info.last_error = None;
+        info.client = Some(client.clone());
+        std::mem::take(&mut info.tools)
+    };
 
+    let mut registered_tools = Vec::new();
     for tool in tools {
+        let tool_name = tool.name.to_string();
         let wrapper = McpTool::new(server_name, tool, client.peer.clone(), runtime.clone());
-        guard.add(Arc::new(wrapper));
+        if guard.register_mcp_tool(server_name, wrapper) {
+            registered_tools.push(tool_name);
+        }
+    }
+    let registered_set: HashSet<_> = registered_tools.iter().cloned().collect();
+
+    for old_tool in previous_tools {
+        if registered_set.contains(&old_tool) {
+            continue;
+        }
+        if guard.mcp_tool_owners.get(&old_tool).map(String::as_str) == Some(server_name) {
+            guard.mcp_tool_owners.remove(&old_tool);
+            guard.tools.remove(&old_tool);
+        }
+    }
+    if let Some(info) = guard.mcp_servers.get_mut(server_name) {
+        info.tools = registered_tools;
     }
 
     Ok(())

--- a/kimi-agent/src/soul/toolset.rs
+++ b/kimi-agent/src/soul/toolset.rs
@@ -555,7 +555,13 @@ pub struct HttpServerConfig {
 pub fn parse_mcp_config(value: &Value) -> Result<HashMap<String, McpServerConfig>, String> {
     let config: McpConfig = serde_json::from_value(value.clone())
         .map_err(|err| format!("Invalid MCP config: {err}"))?;
-    Ok(config.mcp_servers)
+    config
+        .mcp_servers
+        .into_iter()
+        .map(|(name, server)| {
+            canonicalize_mcp_server_config(server).map(|normalized| (name, normalized))
+        })
+        .collect()
 }
 
 fn build_client_info() -> ClientInfo {
@@ -572,9 +578,32 @@ fn build_client_info() -> ClientInfo {
 }
 
 fn normalize_http_transport(transport: &Option<String>) -> Result<(), String> {
-    match transport.as_deref() {
-        None | Some("http") | Some("streamable-http") => Ok(()),
+    canonical_http_transport(transport.as_deref()).map(|_| ())
+}
+
+fn canonical_http_transport(transport: Option<&str>) -> Result<&'static str, String> {
+    match transport {
+        None | Some("http") | Some("streamable-http") => Ok("streamable-http"),
         Some(other) => Err(format!("Unsupported transport: {other}")),
+    }
+}
+
+fn canonicalize_mcp_server_config(server: McpServerConfig) -> Result<McpServerConfig, String> {
+    match server {
+        McpServerConfig::Stdio(mut stdio) => {
+            if stdio.env.as_ref().is_some_and(HashMap::is_empty) {
+                stdio.env = None;
+            }
+            Ok(McpServerConfig::Stdio(stdio))
+        }
+        McpServerConfig::Http(mut http) => {
+            let transport = canonical_http_transport(http.transport.as_deref())?;
+            http.transport = Some(transport.to_string());
+            if http.headers.as_ref().is_some_and(HashMap::is_empty) {
+                http.headers = None;
+            }
+            Ok(McpServerConfig::Http(http))
+        }
     }
 }
 
@@ -935,5 +964,85 @@ impl CallableTool for McpTool {
             ),
             Err(err) => tool_error("", err.to_string(), "MCP error"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{McpServerConfig, parse_mcp_config};
+
+    #[test]
+    fn parse_mcp_config_canonicalizes_http_transport_aliases() {
+        let config = json!({
+            "mcpServers": {
+                "a": { "url": "https://a.example/mcp" },
+                "b": { "url": "https://b.example/mcp", "transport": "http" },
+                "c": { "url": "https://c.example/mcp", "transport": "streamable-http" }
+            }
+        });
+
+        let parsed = parse_mcp_config(&config).expect("parse should succeed");
+
+        for name in ["a", "b", "c"] {
+            let server = parsed.get(name).expect("server must exist");
+            match server {
+                McpServerConfig::Http(http) => {
+                    assert_eq!(http.transport.as_deref(), Some("streamable-http"));
+                }
+                McpServerConfig::Stdio(_) => panic!("expected HTTP config"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_mcp_config_canonicalizes_empty_maps() {
+        let config = json!({
+            "mcpServers": {
+                "stdio": {
+                    "command": "npx",
+                    "args": [],
+                    "env": {}
+                },
+                "http": {
+                    "url": "https://example.com/mcp",
+                    "headers": {}
+                }
+            }
+        });
+
+        let parsed = parse_mcp_config(&config).expect("parse should succeed");
+
+        match parsed.get("stdio").expect("stdio must exist") {
+            McpServerConfig::Stdio(stdio) => {
+                assert_eq!(stdio.args, Vec::<String>::new());
+                assert!(stdio.env.is_none());
+            }
+            McpServerConfig::Http(_) => panic!("expected stdio config"),
+        }
+
+        match parsed.get("http").expect("http must exist") {
+            McpServerConfig::Http(http) => {
+                assert!(http.headers.is_none());
+                assert_eq!(http.transport.as_deref(), Some("streamable-http"));
+            }
+            McpServerConfig::Stdio(_) => panic!("expected HTTP config"),
+        }
+    }
+
+    #[test]
+    fn parse_mcp_config_rejects_unsupported_http_transport() {
+        let config = json!({
+            "mcpServers": {
+                "bad": {
+                    "url": "https://example.com/mcp",
+                    "transport": "sse"
+                }
+            }
+        });
+
+        let err = parse_mcp_config(&config).expect_err("parse should fail");
+        assert!(err.contains("Unsupported transport: sse"));
     }
 }

--- a/kimi-agent/src/wire/server.rs
+++ b/kimi-agent/src/wire/server.rs
@@ -584,6 +584,8 @@ impl WireRpcState {
 
         cancel_and_wait_active_turn(&self.active_turn).await;
 
+        self.soul.shutdown().await;
+
         self.reject_pending_requests().await;
 
         self.write_queue.shutdown(false);

--- a/kimi-agent/tests/kimisoul_slash_commands.rs
+++ b/kimi-agent/tests/kimisoul_slash_commands.rs
@@ -50,6 +50,7 @@ fn test_flow_skill_registers_skill_and_flow_commands() {
         skill_type: SkillType::Flow,
         dir: KaosPath::unsafe_from_local_path(&skill_dir),
         flow: Some(flow),
+        mcp_servers: Vec::new(),
     };
 
     let mut runtime = fixture.runtime.clone();

--- a/kimi-agent/tests/skill.rs
+++ b/kimi-agent/tests/skill.rs
@@ -8,8 +8,8 @@ use kaos::{
     reset_current_kaos, set_current_kaos, with_current_kaos_scope,
 };
 use kimi_agent::skill::{
-    Skill, SkillType, discover_skills, discover_skills_from_roots, find_user_skills_dir,
-    get_builtin_skills_dir, resolve_skills_roots,
+    Skill, SkillMcpServer, SkillType, discover_skills, discover_skills_from_roots,
+    find_user_skills_dir, get_builtin_skills_dir, resolve_skills_roots,
 };
 
 struct FixedHomeKaos {
@@ -164,6 +164,7 @@ async fn test_discover_skills_parses_frontmatter_and_defaults() {
                 skill_type: SkillType::Standard,
                 dir: KaosPath::unsafe_from_local_path(Path::new("/path/to/alpha")),
                 flow: None,
+                mcp_servers: Vec::new(),
             },
             Skill {
                 name: "beta".to_string(),
@@ -171,6 +172,7 @@ async fn test_discover_skills_parses_frontmatter_and_defaults() {
                 skill_type: SkillType::Standard,
                 dir: KaosPath::unsafe_from_local_path(Path::new("/path/to/beta")),
                 flow: None,
+                mcp_servers: Vec::new(),
             },
         ]
     );
@@ -193,6 +195,55 @@ async fn test_discover_skills_parses_flow_type() {
     assert_eq!(skills[0].skill_type, SkillType::Flow);
     assert!(skills[0].flow.is_some());
     assert_eq!(skills[0].flow.as_ref().unwrap().begin_id, "BEGIN");
+}
+
+#[tokio::test]
+async fn test_discover_skills_parses_mcp_servers() {
+    let root = TempDir::new().expect("temp dir");
+    let root_path = root.path().join("skills");
+    std::fs::create_dir_all(&root_path).expect("create skills root");
+
+    write_skill(
+        &root_path.join("mcp"),
+        "---\nname: mcp\ndescription: MCP skill\nmcp:\n  - name: local\n    type: stdio\n    command: npx\n    args: [\"-y\", \"my-mcp\"]\n  - name: remote\n    type: http\n    url: https://example.com/mcp\n    transport: streamable-http\n---\n# body\n",
+    );
+
+    let skills = discover_skills(&KaosPath::unsafe_from_local_path(&root_path)).await;
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].mcp_servers.len(), 2);
+
+    match &skills[0].mcp_servers[0] {
+        SkillMcpServer::Stdio(server) => {
+            assert_eq!(server.name, "local");
+            assert_eq!(server.command, "npx");
+            assert_eq!(server.args, vec!["-y".to_string(), "my-mcp".to_string()]);
+        }
+        _ => panic!("expected stdio mcp server"),
+    }
+
+    match &skills[0].mcp_servers[1] {
+        SkillMcpServer::Http(server) => {
+            assert_eq!(server.name, "remote");
+            assert_eq!(server.url, "https://example.com/mcp");
+            assert_eq!(server.transport.as_deref(), Some("streamable-http"));
+        }
+        _ => panic!("expected http mcp server"),
+    }
+}
+
+#[tokio::test]
+async fn test_discover_skills_rejects_duplicate_mcp_server_names() {
+    let root = TempDir::new().expect("temp dir");
+    let root_path = root.path().join("skills");
+    std::fs::create_dir_all(&root_path).expect("create skills root");
+
+    write_skill(
+        &root_path.join("dup-mcp"),
+        "---\nname: dup\ndescription: duplicated mcp names\nmcp:\n  - name: same\n    type: stdio\n    command: cmd-a\n  - name: SAME\n    type: stdio\n    command: cmd-b\n---\n# body\n",
+    );
+
+    let skills = discover_skills(&KaosPath::unsafe_from_local_path(&root_path)).await;
+    assert!(skills.is_empty());
 }
 
 #[tokio::test]
@@ -251,6 +302,7 @@ async fn test_discover_skills_from_roots_prefers_later_dirs() {
             skill_type: SkillType::Standard,
             dir: KaosPath::unsafe_from_local_path(Path::new("/path/to/user/shared")),
             flow: None,
+            mcp_servers: Vec::new(),
         }]
     );
 }


### PR DESCRIPTION
## Summary
This PR adds skill-scoped MCP lazy loading from `SKILL.md` frontmatter and ensures MCP resources are cleaned up when the wire session ends.

## What changed
- Extended skill frontmatter parsing to support `mcp` entries (`stdio`/`http`), with scoped server naming and duplicate-name validation.
- Added lazy MCP initialization before `/skill:*` and `/flow:*` execution. If required MCP servers are not ready, that skill invocation is stopped with a clear error.
- Updated MCP tool registration behavior:
  - MCP tools can override previously registered MCP tools.
  - Builtin/external non-MCP tools are protected from override.
- Added toolset cleanup logic to close MCP services and remove MCP-owned tools.
- Wired soul shutdown into wire session shutdown so session teardown always triggers MCP cleanup.
- Updated and added tests for skill parsing and slash-command behavior.

## Example `SKILL.md`
```markdown
---
name: my-skill
description: Use this skill when working with an internal knowledge base and issue tracker.
type: standard
mcp:
  - name: knowledge-base
    type: stdio
    command: npx
    args:
      - -y
      - @example/knowledge-mcp
    env:
      KB_API_KEY: ${KB_API_KEY}
  - name: issue-tracker
    type: http
    url: https://mcp.example.com/issues
    transport: streamable-http
    headers:
      Authorization: Bearer ${ISSUE_TOKEN}
---

# Skill workflow
1. Gather requirements from the user task.
2. Use MCP tools from `knowledge-base` to collect relevant docs.
3. Use MCP tools from `issue-tracker` to inspect or update tickets.
4. Return a concise execution summary and next steps.
```

## Validation
- `cargo fmt`
- `cargo test -p kimi-agent skill`
- `cargo clippy --workspace --all-targets`

Closes #5
