### PR TITLE
feat(env): add backend-scoped env resolution to Rust runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,40 +12,39 @@
 
 ## Purpose and naming
 
-Kimi Agent is the Rust rewrite of the Python `kimi-cli` runtime. It is a wire-only agent server
+Kimi Agent is the Rust implementation of the Kimi wire runtime. It is a wire-only agent server
 (no Shell/Print/ACP UI) and lives in this repository. The binary name is `kimi-agent`, but the wire
-protocol identity stays aligned with Python:
+protocol identity stays aligned with the existing Kimi wire ecosystem:
 
 - Wire metadata and user-agent still identify as "Kimi Code CLI" / `KimiCLI/<VERSION>`.
-- Tool identifiers remain `kimi_cli.tools.*` for compatibility.
+- Tool identifiers remain `kimi_cli.tools.*` for wire compatibility.
 - The CLI `about` string is "Kimi Agent, the Rust agent server."
 
-## Sync contract with Python (must-follow)
+## Wire compatibility contract (must-follow)
 
-The Rust and Python implementations must stay in lockstep for any external behavior:
+Rust is allowed to evolve independently. The hard compatibility requirement is the wire protocol and
+other wire-visible contracts:
 
 - Wire protocol, message envelopes, error codes (`docs/zh/customization/wire-mode.md`).
 - `kosong.message` and `kimi_cli.wire.types` schemas and serde behavior.
-- Config, metadata, sessions, and context JSONL formats under `~/.kimi`.
-- Agent specs, prompts, skills/flows, tool schemas/descriptions, approvals, compaction.
-- Providers and Kaos behavior (Kimi/Echo/ScriptedEcho, LocalKaos).
 - Internal IDs and names that appear on the wire must remain stable.
+- Tool identifiers, tool schemas, and other wire-visible metadata must remain stable.
 
-When in doubt, Python (`src/kimi_cli`, `packages/kosong`, `packages/kaos`) and `docs/zh/`
-are the source of truth, and both sides should change together.
+Rust runtime behavior, local persistence, provider semantics, Kaos behavior, prompts, and other
+non-wire internals may diverge when that leads to a cleaner design. Treat Python as a useful
+reference, not as the default source of truth.
 
 ## Versioning (must-follow)
 
-The Rust workspace version must always match the Python `kimi-cli` version exactly
-(`MAJOR.MINOR.PATCH`). Rust may lag behind in feature completeness, but the
-version number must not diverge from the corresponding Python release.
+The Rust workspace version is managed by the Rust project itself. It does not need to match Python
+`kimi-cli` exactly unless a separate release policy explicitly requires that.
 
 ## Rewrite constraints (from _/PROMPT.md and _/PLAN.md)
 
 - Three crates: `kimi-agent`, `kosong`, `kaos`.
 - Rust edition 2024, async runtime `tokio`, serde, anyhow/thiserror, clap, reqwest.
 - Only Wire transports (stdio/WebSocket); no Shell/Print/ACP UI.
-- Full parity with Python for data formats and wire behavior.
+- Wire compatibility is required; full Python parity is not.
 - Tests are ported for core runtime/tools/wire; UI-only tests are omitted.
 
 ## Workspace layout
@@ -60,16 +59,13 @@ version number must not diverge from the corresponding Python release.
 - `--wire` exists but is hidden and ignored (legacy compatibility).
 - No `--prompt`/`--command` because wire server does not accept an initial prompt.
 - Subcommands: `info`, `mcp` only.
-- Help text mirrors Python; some MCP examples still show `kimi` for parity.
+- Help text may diverge from Python when Rust behavior intentionally differs.
 
-## Known incompatibilities with Python
+## Python divergence notes
 
-- MCP OAuth credentials location differs from Python fastmcp defaults; Rust uses `rmcp`
-  credential storage paths and is not compatible with fastmcp token locations.
-- Options kept for parity: `--work-dir`, `--session`, `--continue`, `--config`,
-  `--config-file`, `--model`, `--thinking/--no-thinking`, `--yolo`, `--agent`,
-  `--agent-file`, `--mcp-config-file`, `--mcp-config`, `--skills-dir`,
-  `--max-steps-per-turn`, `--max-retries-per-step`, `--max-ralph-iterations`.
+- Divergence from Python is acceptable unless it breaks wire-visible behavior.
+- Existing CLI flags may still mirror earlier Python behavior for migration or UX reasons, but that
+  is a product choice, not a blanket compatibility rule.
 - `help_expected` is enabled in clap, so every CLI arg must define help text.
 
 ## Major Rust modules (kimi-agent)
@@ -86,9 +82,10 @@ version number must not diverge from the corresponding Python release.
 ## Wire protocol and data compatibility
 
 - Wire protocol version `1.2` with JSON-RPC payload compatibility across stdio/WebSocket transports.
-- Data layout under `~/.kimi` must match Python:
-  - `config.toml`, `kimi.json`, session directories, context JSONL, wire JSONL.
 - `Message.content` string/parts serde rules must match Python exactly.
+- Any identifier, schema, or field shape that crosses the wire must remain compatible.
+- Local on-disk formats may evolve independently unless a separate compatibility requirement says
+  otherwise.
 
 ## Providers and tools
 
@@ -96,11 +93,12 @@ version number must not diverge from the corresponding Python release.
 - Kaos: LocalKaos only (SSH Kaos omitted for now).
 - Built-in tools: Shell, Read/Write/Replace/Glob/Grep/ReadMedia, SearchWeb/FetchURL,
   SetTodoList, CreateSubagent, Task, SendDMail, Think; test tools Plus/Compare/Panic.
-- Tool descriptions live under `kimi-agent/src/tools/desc/` and must match Python.
+- Tool descriptions live under `kimi-agent/src/tools/desc/`; wire-visible tool names and schemas
+  must stay stable, but description text may evolve with Rust.
 
 ## MCP integration
 
-- MCP config: `~/.kimi/mcp.json`, same schema as Python.
+- MCP config: `~/.kimi/mcp.json`.
 - Client: `rmcp` with stdio + HTTP transports, OAuth storage compatibility.
 - CLI: `kimi-agent mcp add/list/remove/auth/reset-auth/test`.
 
@@ -115,12 +113,14 @@ version number must not diverge from the corresponding Python release.
 ## Conventions and runtime rules
 
 - Prefer async I/O in runtime code; avoid blocking locks in async contexts.
-- Keep prompts, schemas, error strings, and wire payloads aligned with Python.
-- If any behavior or documented interface changes, update this file and the
-  corresponding Python implementation and tests.
+- Keep wire payloads and wire-visible schemas aligned with the protocol contract.
+- If Rust intentionally diverges from Python in a non-wire area, update this file and the relevant
+  Rust-side tests/docs instead of assuming Python must change too.
 
 ## Pointers for future updates
 
 - `_/PROMPT.md` defines the rewrite scope and compatibility constraints.
-- `_/PLAN.md` records the parity plan and progress; treat it as historical context.
-- Always validate against the actual Rust code and Python behavior when in conflict.
+- `_/PLAN.md` records earlier parity planning; treat it as historical context, not as a hard
+  constraint.
+- When Rust and Python differ, prefer the explicit wire contract and current Rust design over
+  implicit parity assumptions.

--- a/kaos/src/lib.rs
+++ b/kaos/src/lib.rs
@@ -132,6 +132,7 @@ pub trait Kaos: Send + Sync {
     async fn write_text(&self, path: &KaosPath, data: &str, append: bool) -> Result<usize>;
     async fn chmod(&self, path: &KaosPath, mode: u32) -> Result<()>;
     async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> Result<()>;
+    async fn env_var(&self, key: &str) -> Result<Option<String>>;
     async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>>;
 }
 
@@ -222,6 +223,10 @@ pub async fn chmod(path: &KaosPath, mode: u32) -> Result<()> {
 
 pub async fn mkdir(path: &KaosPath, parents: bool, exist_ok: bool) -> Result<()> {
     get_current_kaos().mkdir(path, parents, exist_ok).await
+}
+
+pub async fn env_var(key: &str) -> Result<Option<String>> {
+    get_current_kaos().env_var(key).await
 }
 
 pub async fn exec(args: &[String]) -> Result<Box<dyn KaosProcess>> {

--- a/kaos/src/local.rs
+++ b/kaos/src/local.rs
@@ -548,30 +548,66 @@ fn system_time_to_f64(time: SystemTime) -> f64 {
 mod tests {
     use super::LocalKaos;
     use crate::Kaos;
+    use tokio::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+    struct EnvGuard {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, prev }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            if let Some(prev) = &self.prev {
+                // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+                unsafe {
+                    std::env::set_var(self.key, prev);
+                }
+            } else {
+                // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+                unsafe {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
 
     #[tokio::test]
     async fn env_var_reads_local_process_environment() {
-        // SAFETY: test process controls this variable for the duration of the test.
-        unsafe {
-            std::env::set_var("KAOS_TEST_ENV_VAR", "local-value");
-        }
+        let _lock = ENV_LOCK.lock().await;
+        let _guard = EnvGuard::set("KAOS_TEST_ENV_VAR", "local-value");
         let kaos = LocalKaos::new();
         assert_eq!(
             kaos.env_var("KAOS_TEST_ENV_VAR").await.expect("read env"),
             Some("local-value".to_string())
         );
-        // SAFETY: test process controls this variable for the duration of the test.
-        unsafe {
-            std::env::remove_var("KAOS_TEST_ENV_VAR");
-        }
     }
 
     #[tokio::test]
     async fn env_var_returns_none_for_missing_values() {
-        // SAFETY: test process controls this variable for the duration of the test.
-        unsafe {
-            std::env::remove_var("KAOS_TEST_ENV_VAR_MISSING");
-        }
+        let _lock = ENV_LOCK.lock().await;
+        let _guard = EnvGuard::remove("KAOS_TEST_ENV_VAR_MISSING");
         let kaos = LocalKaos::new();
         assert_eq!(
             kaos.env_var("KAOS_TEST_ENV_VAR_MISSING")

--- a/kaos/src/local.rs
+++ b/kaos/src/local.rs
@@ -418,6 +418,16 @@ impl Kaos for LocalKaos {
         Ok(())
     }
 
+    async fn env_var(&self, key: &str) -> Result<Option<String>> {
+        match std::env::var(key) {
+            Ok(value) => Ok(Some(value)),
+            Err(std::env::VarError::NotPresent) => Ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => {
+                Err(anyhow!("Environment variable `{key}` is not valid UTF-8"))
+            }
+        }
+    }
+
     async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>> {
         if args.is_empty() {
             return Err(anyhow!("missing command"));
@@ -532,4 +542,42 @@ fn system_time_to_f64(time: SystemTime) -> f64 {
     time.duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs_f64())
         .unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LocalKaos;
+    use crate::Kaos;
+
+    #[tokio::test]
+    async fn env_var_reads_local_process_environment() {
+        // SAFETY: test process controls this variable for the duration of the test.
+        unsafe {
+            std::env::set_var("KAOS_TEST_ENV_VAR", "local-value");
+        }
+        let kaos = LocalKaos::new();
+        assert_eq!(
+            kaos.env_var("KAOS_TEST_ENV_VAR").await.expect("read env"),
+            Some("local-value".to_string())
+        );
+        // SAFETY: test process controls this variable for the duration of the test.
+        unsafe {
+            std::env::remove_var("KAOS_TEST_ENV_VAR");
+        }
+    }
+
+    #[tokio::test]
+    async fn env_var_returns_none_for_missing_values() {
+        // SAFETY: test process controls this variable for the duration of the test.
+        unsafe {
+            std::env::remove_var("KAOS_TEST_ENV_VAR_MISSING");
+        }
+        let kaos = LocalKaos::new();
+        assert_eq!(
+            kaos.env_var("KAOS_TEST_ENV_VAR_MISSING")
+                .await
+                .expect("read env"),
+            None
+        );
+    }
 }

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -565,15 +565,11 @@ impl Kaos for SshKaos {
         }
 
         let command = format!(
-            "if [ \"${{{key}+x}}\" = x ]; then printf '%s' \"${{{key}}}\"; else exit 1; fi"
+            "if [ \"${{{key}+x}}\" = x ]; then printf '%s' \"${{{key}}}\"; else exit {SSH_ENV_VAR_UNSET_EXIT_CODE}; fi"
         );
         let mut handle = self.state.handle.lock().await;
         let (exit_code, stdout, stderr) = exec_capture_raw(&mut handle, &command).await?;
-        let value = match exit_code {
-            0 => Some(stdout),
-            1 if stderr.is_empty() => None,
-            _ => bail!("Failed to read remote environment variable `{key}`: {stderr}"),
-        };
+        let value = map_env_var_lookup_result(key, exit_code, stdout, stderr)?;
 
         self.state
             .env_cache
@@ -1151,6 +1147,21 @@ async fn exec_capture_raw(
     ))
 }
 
+const SSH_ENV_VAR_UNSET_EXIT_CODE: i32 = 3;
+
+fn map_env_var_lookup_result(
+    key: &str,
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+) -> Result<Option<String>> {
+    match exit_code {
+        0 => Ok(Some(stdout)),
+        SSH_ENV_VAR_UNSET_EXIT_CODE => Ok(None),
+        _ => bail!("Failed to read remote environment variable `{key}`: {stderr}"),
+    }
+}
+
 async fn mkdir_once(sftp: &SftpSession, path: &str, exist_ok: bool) -> Result<()> {
     match sftp.create_dir(path).await {
         Ok(()) => Ok(()),
@@ -1322,7 +1333,8 @@ fn build_storage_name(host: &str, port: u16, username: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        GlobTraversalPlan, build_storage_name, normalize_glob_pattern, resolve_absolute_posix,
+        GlobTraversalPlan, SSH_ENV_VAR_UNSET_EXIT_CODE, build_storage_name,
+        map_env_var_lookup_result, normalize_glob_pattern, resolve_absolute_posix,
         validate_env_var_key,
     };
     use crate::{KaosPath, KaosPathStyle};
@@ -1402,5 +1414,32 @@ mod tests {
         assert!(validate_env_var_key("").is_err());
         assert!(validate_env_var_key("1PATH").is_err());
         assert!(validate_env_var_key("BAD-NAME").is_err());
+    }
+
+    #[test]
+    fn map_env_var_lookup_result_returns_value_for_success() {
+        let value = map_env_var_lookup_result("PATH", 0, "value ".to_string(), "noise".to_string())
+            .expect("success");
+        assert_eq!(value, Some("value ".to_string()));
+    }
+
+    #[test]
+    fn map_env_var_lookup_result_returns_none_for_unset_exit_code() {
+        let value = map_env_var_lookup_result(
+            "PATH",
+            SSH_ENV_VAR_UNSET_EXIT_CODE,
+            String::new(),
+            "startup noise".to_string(),
+        )
+        .expect("unset");
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn map_env_var_lookup_result_errors_for_other_failures() {
+        let err =
+            map_env_var_lookup_result("PATH", 1, String::new(), "permission denied".to_string())
+                .expect_err("failure");
+        assert!(err.to_string().contains("permission denied"));
     }
 }

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -96,6 +96,7 @@ struct SshState {
     sftp: SftpSession,
     home: KaosPath,
     cwd: Mutex<KaosPath>,
+    env_cache: AsyncMutex<HashMap<String, Option<String>>>,
     platform: KaosPlatform,
     storage_name: String,
 }
@@ -241,6 +242,7 @@ impl SshKaos {
                 sftp,
                 home,
                 cwd: Mutex::new(cwd),
+                env_cache: AsyncMutex::new(HashMap::new()),
                 platform,
                 storage_name,
             }),
@@ -553,6 +555,32 @@ impl Kaos for SshKaos {
             mkdir_once(&self.state.sftp, current.as_str(), allow_existing).await?;
         }
         Ok(())
+    }
+
+    async fn env_var(&self, key: &str) -> Result<Option<String>> {
+        validate_env_var_key(key)?;
+
+        if let Some(cached) = self.state.env_cache.lock().await.get(key).cloned() {
+            return Ok(cached);
+        }
+
+        let command = format!(
+            "if [ \"${{{key}+x}}\" = x ]; then printf '%s' \"${{{key}}}\"; else exit 1; fi"
+        );
+        let mut handle = self.state.handle.lock().await;
+        let (exit_code, stdout, stderr) = exec_capture_raw(&mut handle, &command).await?;
+        let value = match exit_code {
+            0 => Some(stdout),
+            1 if stderr.is_empty() => None,
+            _ => bail!("Failed to read remote environment variable `{key}`: {stderr}"),
+        };
+
+        self.state
+            .env_cache
+            .lock()
+            .await
+            .insert(key.to_string(), value.clone());
+        Ok(value)
     }
 
     async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>> {
@@ -1091,6 +1119,14 @@ async fn exec_capture(
     handle: &mut client::Handle<SshClientHandler>,
     command: &str,
 ) -> Result<(i32, String, String)> {
+    let (code, stdout, stderr) = exec_capture_raw(handle, command).await?;
+    Ok((code, stdout.trim().to_string(), stderr.trim().to_string()))
+}
+
+async fn exec_capture_raw(
+    handle: &mut client::Handle<SshClientHandler>,
+    command: &str,
+) -> Result<(i32, String, String)> {
     let mut channel = handle.channel_open_session().await?;
     channel.exec(true, command).await?;
 
@@ -1110,8 +1146,8 @@ async fn exec_capture(
 
     Ok((
         code.unwrap_or(1),
-        String::from_utf8_lossy(&stdout).trim().to_string(),
-        String::from_utf8_lossy(&stderr).trim().to_string(),
+        String::from_utf8_lossy(&stdout).to_string(),
+        String::from_utf8_lossy(&stderr).to_string(),
     ))
 }
 
@@ -1153,6 +1189,21 @@ fn normalize_arch(raw: &str) -> String {
         "x86" | "i386" | "i686" => "x86".to_string(),
         other if !other.is_empty() => other.to_string(),
         _ => "x86_64".to_string(),
+    }
+}
+
+fn validate_env_var_key(key: &str) -> Result<()> {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        bail!("Environment variable name cannot be empty");
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        bail!("Invalid environment variable name `{key}`");
+    }
+    if chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric()) {
+        Ok(())
+    } else {
+        bail!("Invalid environment variable name `{key}`");
     }
 }
 
@@ -1272,6 +1323,7 @@ fn build_storage_name(host: &str, port: u16, username: &str) -> String {
 mod tests {
     use super::{
         GlobTraversalPlan, build_storage_name, normalize_glob_pattern, resolve_absolute_posix,
+        validate_env_var_key,
     };
     use crate::{KaosPath, KaosPathStyle};
 
@@ -1337,5 +1389,18 @@ mod tests {
         assert_eq!(normalize_glob_pattern("./*.rs"), "*.rs");
         assert_eq!(normalize_glob_pattern("./src/**/*.rs"), "src/**/*.rs");
         assert_eq!(normalize_glob_pattern("*.rs"), "*.rs");
+    }
+
+    #[test]
+    fn validate_env_var_key_accepts_posix_identifiers() {
+        assert!(validate_env_var_key("PATH").is_ok());
+        assert!(validate_env_var_key("_TOKEN_2").is_ok());
+    }
+
+    #[test]
+    fn validate_env_var_key_rejects_invalid_identifiers() {
+        assert!(validate_env_var_key("").is_err());
+        assert!(validate_env_var_key("1PATH").is_err());
+        assert!(validate_env_var_key("BAD-NAME").is_err());
     }
 }

--- a/kimi-agent/src/app.rs
+++ b/kimi-agent/src/app.rs
@@ -21,6 +21,8 @@ use crate::soul::run_soul;
 use crate::wire::WireMessage;
 use crate::wire::server::{WireServer, WireWsServer, WsSessionRuntimeOptions};
 
+const DEFAULT_FALLBACK_MAX_CONTEXT_SIZE: i64 = 100_000;
+
 pub struct KimiCLI {
     soul: Arc<KimiSoul>,
     runtime: Runtime,
@@ -111,7 +113,7 @@ impl KimiCLI {
             model = Some(LLMModel {
                 provider: "".to_string(),
                 model: "".to_string(),
-                max_context_size: 100_000,
+                max_context_size: 0,
                 capabilities: None,
             });
             provider = Some(LLMProvider {
@@ -139,6 +141,9 @@ impl KimiCLI {
         let env_overrides = augment_provider_with_env_vars(&mut provider, &mut model)
             .await
             .map_err(anyhow::Error::new)?;
+        if model.max_context_size <= 0 {
+            model.max_context_size = DEFAULT_FALLBACK_MAX_CONTEXT_SIZE;
+        }
 
         let thinking = thinking.unwrap_or(config.default_thinking);
         info!(thinking, "Thinking mode");

--- a/kimi-agent/src/app.rs
+++ b/kimi-agent/src/app.rs
@@ -137,6 +137,7 @@ impl KimiCLI {
             "Using LLM model"
         );
         let env_overrides = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
             .map_err(anyhow::Error::new)?;
 
         let thinking = thinking.unwrap_or(config.default_thinking);

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -381,7 +381,8 @@ fn parse_env_f64(value: &str) -> Result<f64, LLMError> {
 async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
     // Provider/model env overrides are intentionally scoped to the active backend.
     // This keeps LLM configuration aligned with the selected kaos environment
-    // instead of the launcher process environment. Host-local bootstrap
+    // instead of the launcher process environment, even though the HTTP client
+    // itself still runs in the local Rust process. Host-local bootstrap
     // exceptions such as KIMI_SHARE_DIR live outside this module.
     kaos::env_var(key).await.map_err(|err| {
         LLMError::EnvVar(format!(

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -56,6 +56,10 @@ pub async fn augment_provider_with_env_vars(
     provider: &mut LLMProvider,
     model: &mut LLMModel,
 ) -> Result<HashMap<String, String>, LLMError> {
+    // Env resolution for LLM configuration is intentionally backend-scoped:
+    // provider.env is checked first, then the active kaos backend environment.
+    // Explicit config still wins over ambient env, so env only fills fields
+    // that are missing from config.toml.
     let mut applied = HashMap::new();
     let missing_provider_base_url = provider.base_url.is_empty();
     let missing_provider_api_key = provider.api_key.is_empty();
@@ -80,6 +84,8 @@ pub async fn augment_provider_with_env_vars(
     }
 
     if provider.provider_type == ProviderType::Kimi {
+        // Kimi model metadata follows the same config-first contract as
+        // provider credentials: backend env supplies defaults, not overrides.
         if model.model.is_empty()
             && let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
                 .await?
@@ -471,6 +477,8 @@ fn apply_resolved_provider_credentials_if_missing(
     provider: &mut LLMProvider,
     credentials: &ResolvedProviderCredentials,
 ) {
+    // Ambient env is allowed to complete provider config, but not replace
+    // explicit values that were already chosen in config.toml.
     if provider.base_url.is_empty()
         && let Some((_, base_url)) = credentials.base_url.as_ref()
     {

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -57,6 +57,8 @@ pub async fn augment_provider_with_env_vars(
     model: &mut LLMModel,
 ) -> Result<HashMap<String, String>, LLMError> {
     let mut applied = HashMap::new();
+    let missing_provider_base_url = provider.base_url.is_empty();
+    let missing_provider_api_key = provider.api_key.is_empty();
     let resolved_credentials = if let Some(env_keys) =
         provider_credential_env_keys(&provider.provider_type)
     {
@@ -66,36 +68,39 @@ pub async fn augment_provider_with_env_vars(
     };
 
     if let Some(credentials) = resolved_credentials.as_ref() {
-        apply_resolved_provider_credentials(provider, credentials);
+        apply_resolved_provider_credentials_if_missing(provider, credentials);
         if provider.provider_type == ProviderType::Kimi {
-            if let Some((key, value)) = credentials.base_url.as_ref() {
+            if missing_provider_base_url && let Some((key, value)) = credentials.base_url.as_ref() {
                 applied.insert((*key).to_string(), value.clone());
             }
-            if let Some((key, _)) = credentials.api_key.as_ref() {
+            if missing_provider_api_key && let Some((key, _)) = credentials.api_key.as_ref() {
                 applied.insert((*key).to_string(), "******".to_string());
             }
         }
     }
 
     if provider.provider_type == ProviderType::Kimi {
-        if let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
-            .await?
-            .filter(|value| !value.is_empty())
+        if model.model.is_empty()
+            && let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
+                .await?
+                .filter(|value| !value.is_empty())
         {
             model.model = model_name.clone();
             applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
         }
-        if let Some(max_context_size) = read_backend_env_var("KIMI_MODEL_MAX_CONTEXT_SIZE")
-            .await?
-            .filter(|value| !value.is_empty())
+        if model.max_context_size <= 0
+            && let Some(max_context_size) = read_backend_env_var("KIMI_MODEL_MAX_CONTEXT_SIZE")
+                .await?
+                .filter(|value| !value.is_empty())
         {
             let value = parse_env_i64(&max_context_size)?;
             model.max_context_size = value;
             applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
         }
-        if let Some(caps) = read_backend_env_var("KIMI_MODEL_CAPABILITIES")
-            .await?
-            .filter(|value| !value.is_empty())
+        if model.capabilities.is_none()
+            && let Some(caps) = read_backend_env_var("KIMI_MODEL_CAPABILITIES")
+                .await?
+                .filter(|value| !value.is_empty())
         {
             let mut parsed = HashSet::new();
             for cap in caps.split(',').map(|s| s.trim().to_lowercase()) {
@@ -435,10 +440,10 @@ fn openai_compat_env_profile(provider_type: &ProviderType) -> Option<OpenAiCompa
         ProviderType::GoogleGenai | ProviderType::Gemini => Some(OpenAiCompatEnvProfile {
             provider_name: "google_genai",
             credentials: ProviderCredentialEnvKeys {
-                base_url: &["GEMINI_BASE_URL", "GOOGLE_GENAI_BASE_URL"],
-                api_key: &["GEMINI_API_KEY", "GOOGLE_GENAI_API_KEY"],
+                base_url: &["GEMINI_BASE_URL"],
+                api_key: &["GEMINI_API_KEY"],
             },
-            temperature: &["GEMINI_MODEL_TEMPERATURE", "GOOGLE_GENAI_MODEL_TEMPERATURE"],
+            temperature: &["GEMINI_MODEL_TEMPERATURE"],
         }),
         ProviderType::Vertexai => Some(OpenAiCompatEnvProfile {
             provider_name: "vertexai",
@@ -462,14 +467,18 @@ async fn resolve_provider_credentials_from_env_sources(
     })
 }
 
-fn apply_resolved_provider_credentials(
+fn apply_resolved_provider_credentials_if_missing(
     provider: &mut LLMProvider,
     credentials: &ResolvedProviderCredentials,
 ) {
-    if let Some((_, base_url)) = credentials.base_url.as_ref() {
+    if provider.base_url.is_empty()
+        && let Some((_, base_url)) = credentials.base_url.as_ref()
+    {
         provider.base_url = base_url.clone();
     }
-    if let Some((_, api_key)) = credentials.api_key.as_ref() {
+    if provider.api_key.is_empty()
+        && let Some((_, api_key)) = credentials.api_key.as_ref()
+    {
         provider.api_key = api_key.clone();
     }
 }

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::env;
 use std::path::PathBuf;
 
 use serde_json::{Map, Value};
@@ -34,7 +33,7 @@ impl LLM {
     }
 }
 
-pub fn augment_provider_with_env_vars(
+pub async fn augment_provider_with_env_vars(
     provider: &mut LLMProvider,
     model: &mut LLMModel,
 ) -> Result<HashMap<String, String>, LLMError> {
@@ -42,33 +41,38 @@ pub fn augment_provider_with_env_vars(
 
     match provider.provider_type {
         ProviderType::Kimi => {
-            if let Ok(base_url) = env::var("KIMI_BASE_URL")
-                && !base_url.is_empty()
+            if let Some(base_url) = read_backend_env_var("KIMI_BASE_URL")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 provider.base_url = base_url.clone();
                 applied.insert("KIMI_BASE_URL".to_string(), base_url);
             }
-            if let Ok(api_key) = env::var("KIMI_API_KEY")
-                && !api_key.is_empty()
+            if let Some(api_key) = read_backend_env_var("KIMI_API_KEY")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 provider.api_key = api_key;
                 applied.insert("KIMI_API_KEY".to_string(), "******".to_string());
             }
-            if let Ok(model_name) = env::var("KIMI_MODEL_NAME")
-                && !model_name.is_empty()
+            if let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 model.model = model_name.clone();
                 applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
             }
-            if let Ok(max_context_size) = env::var("KIMI_MODEL_MAX_CONTEXT_SIZE")
-                && !max_context_size.is_empty()
+            if let Some(max_context_size) = read_backend_env_var("KIMI_MODEL_MAX_CONTEXT_SIZE")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let value = parse_env_i64(&max_context_size)?;
                 model.max_context_size = value;
                 applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
             }
-            if let Ok(caps) = env::var("KIMI_MODEL_CAPABILITIES")
-                && !caps.is_empty()
+            if let Some(caps) = read_backend_env_var("KIMI_MODEL_CAPABILITIES")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let mut parsed = HashSet::new();
                 for cap in caps.split(',').map(|s| s.trim().to_lowercase()) {
@@ -93,13 +97,15 @@ pub fn augment_provider_with_env_vars(
             }
         }
         ProviderType::OpenaiLegacy | ProviderType::OpenaiResponses => {
-            if let Ok(base_url) = env::var("OPENAI_BASE_URL")
-                && !base_url.is_empty()
+            if let Some(base_url) = read_backend_env_var("OPENAI_BASE_URL")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 provider.base_url = base_url;
             }
-            if let Ok(api_key) = env::var("OPENAI_API_KEY")
-                && !api_key.is_empty()
+            if let Some(api_key) = read_backend_env_var("OPENAI_API_KEY")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 provider.api_key = api_key;
             }
@@ -142,20 +148,23 @@ pub async fn create_llm(
                     Value::String(session_id.to_string()),
                 );
             }
-            if let Ok(value) = env::var("KIMI_MODEL_TEMPERATURE")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("KIMI_MODEL_TEMPERATURE")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_f64(&value)?;
                 kwargs.insert("temperature".to_string(), Value::from(parsed));
             }
-            if let Ok(value) = env::var("KIMI_MODEL_TOP_P")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("KIMI_MODEL_TOP_P")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_f64(&value)?;
                 kwargs.insert("top_p".to_string(), Value::from(parsed));
             }
-            if let Ok(value) = env::var("KIMI_MODEL_MAX_TOKENS")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("KIMI_MODEL_MAX_TOKENS")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_i64(&value)?;
                 kwargs.insert("max_tokens".to_string(), Value::from(parsed));
@@ -173,8 +182,9 @@ pub async fn create_llm(
                 Some(default_headers.clone()),
             )
             .map_err(map_chat_provider_error)?;
-            if let Ok(value) = env::var("OPENAI_MODEL_TEMPERATURE")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("OPENAI_MODEL_TEMPERATURE")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_f64(&value)?;
                 let mut kwargs = Map::new();
@@ -191,8 +201,9 @@ pub async fn create_llm(
                 Some(default_headers.clone()),
             )
             .map_err(map_chat_provider_error)?;
-            if let Ok(value) = env::var("OPENAI_MODEL_TEMPERATURE")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("OPENAI_MODEL_TEMPERATURE")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_f64(&value)?;
                 let mut kwargs = Map::new();
@@ -212,21 +223,24 @@ pub async fn create_llm(
 
             let mut kwargs = Map::new();
             kwargs.insert("max_tokens".to_string(), Value::from(50_000));
-            if let Ok(value) = env::var("ANTHROPIC_MODEL_TEMPERATURE")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("ANTHROPIC_MODEL_TEMPERATURE")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 kwargs.insert(
                     "temperature".to_string(),
                     Value::from(parse_env_f64(&value)?),
                 );
             }
-            if let Ok(value) = env::var("ANTHROPIC_MODEL_TOP_P")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("ANTHROPIC_MODEL_TOP_P")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 kwargs.insert("top_p".to_string(), Value::from(parse_env_f64(&value)?));
             }
-            if let Ok(value) = env::var("ANTHROPIC_MODEL_MAX_TOKENS")
-                && !value.is_empty()
+            if let Some(value) = read_backend_env_var("ANTHROPIC_MODEL_MAX_TOKENS")
+                .await?
+                .filter(|value| !value.is_empty())
             {
                 kwargs.insert(
                     "max_tokens".to_string(),
@@ -261,7 +275,8 @@ pub async fn create_llm(
                 &provider.base_url,
                 provider.env.as_ref(),
                 "OPENAI_BASE_URL",
-            );
+            )
+            .await?;
             Box::new(
                 kosong::chat_provider::openai_legacy::OpenAILegacy::new(
                     model.model.clone(),
@@ -277,6 +292,7 @@ pub async fn create_llm(
         ProviderType::ScriptedEcho => {
             let scripts = load_scripted_echo_scripts(provider.env.as_ref()).await?;
             let trace = read_env_var(provider.env.as_ref(), "KIMI_SCRIPTED_ECHO_TRACE")
+                .await?
                 .unwrap_or_default()
                 .trim()
                 .to_lowercase();
@@ -371,11 +387,22 @@ fn parse_env_f64(value: &str) -> Result<f64, LLMError> {
         .map_err(|_| LLMError::EnvVar(format!("could not convert string to float: '{}'", value)))
 }
 
-fn read_env_var(provider_env: Option<&HashMap<String, String>>, key: &str) -> Option<String> {
-    provider_env
-        .and_then(|envs| envs.get(key))
-        .cloned()
-        .or_else(|| env::var(key).ok())
+async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
+    kaos::env_var(key).await.map_err(|err| {
+        LLMError::EnvVar(format!(
+            "failed to read environment variable `{key}`: {err}"
+        ))
+    })
+}
+
+async fn read_env_var(
+    provider_env: Option<&HashMap<String, String>>,
+    key: &str,
+) -> Result<Option<String>, LLMError> {
+    if let Some(value) = provider_env.and_then(|envs| envs.get(key)).cloned() {
+        return Ok(Some(value));
+    }
+    read_backend_env_var(key).await
 }
 
 fn non_empty_provider_value(value: &str) -> Option<String> {
@@ -386,15 +413,17 @@ fn non_empty_provider_value(value: &str) -> Option<String> {
     }
 }
 
-fn resolve_provider_value(
+async fn resolve_provider_value(
     value: &str,
     provider_env: Option<&HashMap<String, String>>,
     env_key: &str,
-) -> String {
+) -> Result<String, LLMError> {
     if !value.is_empty() {
-        return value.to_string();
+        return Ok(value.to_string());
     }
-    read_env_var(provider_env, env_key).unwrap_or_default()
+    Ok(read_env_var(provider_env, env_key)
+        .await?
+        .unwrap_or_default())
 }
 
 fn resolve_provider_value_with_explicit_env(
@@ -411,8 +440,9 @@ fn resolve_provider_value_with_explicit_env(
 async fn load_scripted_echo_scripts(
     provider_env: Option<&HashMap<String, String>>,
 ) -> Result<Vec<String>, LLMError> {
-    let script_path =
-        read_env_var(provider_env, "KIMI_SCRIPTED_ECHO_SCRIPTS").ok_or_else(|| {
+    let script_path = read_env_var(provider_env, "KIMI_SCRIPTED_ECHO_SCRIPTS")
+        .await?
+        .ok_or_else(|| {
             LLMError::ScriptedEcho(
                 "KIMI_SCRIPTED_ECHO_SCRIPTS is required for _scripted_echo.".to_string(),
             )

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -52,6 +52,22 @@ struct OpenAiCompatEnvProfile {
     temperature: &'static [&'static str],
 }
 
+#[derive(Clone, Copy)]
+enum EnvLookupMode {
+    Strict,
+    BestEffort,
+}
+
+const KIMI_MODEL_NAME_KEYS: &[&str] = &["KIMI_MODEL_NAME"];
+const KIMI_MODEL_MAX_CONTEXT_SIZE_KEYS: &[&str] = &["KIMI_MODEL_MAX_CONTEXT_SIZE"];
+const KIMI_MODEL_CAPABILITIES_KEYS: &[&str] = &["KIMI_MODEL_CAPABILITIES"];
+const KIMI_MODEL_TEMPERATURE_KEYS: &[&str] = &["KIMI_MODEL_TEMPERATURE"];
+const KIMI_MODEL_TOP_P_KEYS: &[&str] = &["KIMI_MODEL_TOP_P"];
+const KIMI_MODEL_MAX_TOKENS_KEYS: &[&str] = &["KIMI_MODEL_MAX_TOKENS"];
+const ANTHROPIC_MODEL_TEMPERATURE_KEYS: &[&str] = &["ANTHROPIC_MODEL_TEMPERATURE"];
+const ANTHROPIC_MODEL_TOP_P_KEYS: &[&str] = &["ANTHROPIC_MODEL_TOP_P"];
+const ANTHROPIC_MODEL_MAX_TOKENS_KEYS: &[&str] = &["ANTHROPIC_MODEL_MAX_TOKENS"];
+
 pub async fn augment_provider_with_env_vars(
     provider: &mut LLMProvider,
     model: &mut LLMModel,
@@ -93,52 +109,7 @@ pub async fn augment_provider_with_env_vars(
     }
 
     if provider.provider_type == ProviderType::Kimi {
-        // Kimi model metadata follows the same config-first contract as
-        // provider credentials: backend env supplies defaults, not overrides.
-        if model.model.is_empty()
-            && let Some(model_name) = read_backend_env_var_best_effort("KIMI_MODEL_NAME")
-                .await
-                .filter(|value| !value.is_empty())
-        {
-            model.model = model_name.clone();
-            applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
-        }
-        if model.max_context_size <= 0
-            && let Some(max_context_size) =
-                read_backend_env_var_best_effort("KIMI_MODEL_MAX_CONTEXT_SIZE")
-                    .await
-                    .filter(|value| !value.is_empty())
-        {
-            let value = parse_env_i64(&max_context_size)?;
-            model.max_context_size = value;
-            applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
-        }
-        if model.capabilities.is_none()
-            && let Some(caps) = read_backend_env_var_best_effort("KIMI_MODEL_CAPABILITIES")
-                .await
-                .filter(|value| !value.is_empty())
-        {
-            let mut parsed = HashSet::new();
-            for cap in caps.split(',').map(|s| s.trim().to_lowercase()) {
-                match cap.as_str() {
-                    "image_in" => {
-                        parsed.insert(ModelCapability::ImageIn);
-                    }
-                    "video_in" => {
-                        parsed.insert(ModelCapability::VideoIn);
-                    }
-                    "thinking" => {
-                        parsed.insert(ModelCapability::Thinking);
-                    }
-                    "always_thinking" => {
-                        parsed.insert(ModelCapability::AlwaysThinking);
-                    }
-                    _ => {}
-                }
-            }
-            model.capabilities = Some(parsed);
-            applied.insert("KIMI_MODEL_CAPABILITIES".to_string(), caps);
-        }
+        fill_missing_kimi_model_from_env(provider.env.as_ref(), model, &mut applied).await?;
     }
 
     Ok(applied)
@@ -176,23 +147,32 @@ pub async fn create_llm(
                     Value::String(session_id.to_string()),
                 );
             }
-            if let Some(value) = read_backend_env_var_best_effort("KIMI_MODEL_TEMPERATURE")
-                .await
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                KIMI_MODEL_TEMPERATURE_KEYS,
+                EnvLookupMode::BestEffort,
+            )
+            .await?
             {
                 let parsed = parse_env_f64(&value)?;
                 kwargs.insert("temperature".to_string(), Value::from(parsed));
             }
-            if let Some(value) = read_backend_env_var_best_effort("KIMI_MODEL_TOP_P")
-                .await
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                KIMI_MODEL_TOP_P_KEYS,
+                EnvLookupMode::BestEffort,
+            )
+            .await?
             {
                 let parsed = parse_env_f64(&value)?;
                 kwargs.insert("top_p".to_string(), Value::from(parsed));
             }
-            if let Some(value) = read_backend_env_var_best_effort("KIMI_MODEL_MAX_TOKENS")
-                .await
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                KIMI_MODEL_MAX_TOKENS_KEYS,
+                EnvLookupMode::BestEffort,
+            )
+            .await?
             {
                 let parsed = parse_env_i64(&value)?;
                 kwargs.insert("max_tokens".to_string(), Value::from(parsed));
@@ -219,11 +199,12 @@ pub async fn create_llm(
                 Some(default_headers.clone()),
             )
             .map_err(map_chat_provider_error)?;
-            if let Some(value) = read_non_empty_env_override_var_best_effort(
+            if let Some(value) = read_non_empty_env_override_var(
                 provider.env.as_ref(),
                 &["OPENAI_MODEL_TEMPERATURE"],
+                EnvLookupMode::BestEffort,
             )
-            .await
+            .await?
             {
                 let parsed = parse_env_f64(&value)?;
                 let mut kwargs = Map::new();
@@ -243,24 +224,33 @@ pub async fn create_llm(
 
             let mut kwargs = Map::new();
             kwargs.insert("max_tokens".to_string(), Value::from(50_000));
-            if let Some(value) = read_backend_env_var_best_effort("ANTHROPIC_MODEL_TEMPERATURE")
-                .await
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                ANTHROPIC_MODEL_TEMPERATURE_KEYS,
+                EnvLookupMode::BestEffort,
+            )
+            .await?
             {
                 kwargs.insert(
                     "temperature".to_string(),
                     Value::from(parse_env_f64(&value)?),
                 );
             }
-            if let Some(value) = read_backend_env_var_best_effort("ANTHROPIC_MODEL_TOP_P")
-                .await
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                ANTHROPIC_MODEL_TOP_P_KEYS,
+                EnvLookupMode::BestEffort,
+            )
+            .await?
             {
                 kwargs.insert("top_p".to_string(), Value::from(parse_env_f64(&value)?));
             }
-            if let Some(value) = read_backend_env_var_best_effort("ANTHROPIC_MODEL_MAX_TOKENS")
-                .await
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                ANTHROPIC_MODEL_MAX_TOKENS_KEYS,
+                EnvLookupMode::BestEffort,
+            )
+            .await?
             {
                 kwargs.insert(
                     "max_tokens".to_string(),
@@ -400,35 +390,46 @@ async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
     })
 }
 
-async fn read_backend_env_var_best_effort(key: &str) -> Option<String> {
-    read_backend_env_var(key).await.unwrap_or_default()
+async fn read_backend_env_var_with_mode(
+    key: &str,
+    mode: EnvLookupMode,
+) -> Result<Option<String>, LLMError> {
+    // Missing required config should surface backend/env errors, while
+    // optional tuning/defaults treat backend lookup failures as unset.
+    match read_backend_env_var(key).await {
+        Ok(value) => Ok(value),
+        Err(_) if matches!(mode, EnvLookupMode::BestEffort) => Ok(None),
+        Err(err) => Err(err),
+    }
 }
 
-async fn read_env_override_var_best_effort(
+async fn read_env_override_var(
     provider_env: Option<&HashMap<String, String>>,
     keys: &'static [&'static str],
-) -> Option<(&'static str, String)> {
+    mode: EnvLookupMode,
+) -> Result<Option<(&'static str, String)>, LLMError> {
     for key in keys {
         if let Some(value) = provider_env.and_then(|envs| envs.get(*key)).cloned() {
-            return Some((*key, value));
+            return Ok(Some((*key, value)));
         }
-        if let Some(value) = read_backend_env_var_best_effort(key).await
+        if let Some(value) = read_backend_env_var_with_mode(key, mode).await?
             && !value.is_empty()
         {
-            return Some((*key, value));
+            return Ok(Some((*key, value)));
         }
     }
-    None
+    Ok(None)
 }
 
-async fn read_non_empty_env_override_var_best_effort(
+async fn read_non_empty_env_override_var(
     provider_env: Option<&HashMap<String, String>>,
     keys: &'static [&'static str],
-) -> Option<String> {
-    read_env_override_var_best_effort(provider_env, keys)
-        .await
+    mode: EnvLookupMode,
+) -> Result<Option<String>, LLMError> {
+    Ok(read_env_override_var(provider_env, keys, mode)
+        .await?
         .map(|(_, value)| value)
-        .filter(|value| !value.is_empty())
+        .filter(|value| !value.is_empty()))
 }
 
 fn provider_credential_env_keys(provider_type: &ProviderType) -> Option<ProviderCredentialEnvKeys> {
@@ -485,12 +486,12 @@ async fn resolve_provider_credentials_from_env_sources(
 ) -> Result<ResolvedProviderCredentials, LLMError> {
     Ok(ResolvedProviderCredentials {
         base_url: if resolve_base_url {
-            read_env_override_var_best_effort(provider_env, env_keys.base_url).await
+            read_env_override_var(provider_env, env_keys.base_url, EnvLookupMode::Strict).await?
         } else {
             None
         },
         api_key: if resolve_api_key {
-            read_env_override_var_best_effort(provider_env, env_keys.api_key).await
+            read_env_override_var(provider_env, env_keys.api_key, EnvLookupMode::Strict).await?
         } else {
             None
         },
@@ -536,9 +537,12 @@ async fn build_openai_compat_legacy_provider(
     .map_err(map_chat_provider_error)?
     .with_provider_name(env_profile.provider_name);
 
-    if let Some(value) =
-        read_non_empty_env_override_var_best_effort(provider.env.as_ref(), env_profile.temperature)
-            .await
+    if let Some(value) = read_non_empty_env_override_var(
+        provider.env.as_ref(),
+        env_profile.temperature,
+        EnvLookupMode::BestEffort,
+    )
+    .await?
     {
         let parsed = parse_env_f64(&value)?;
         let mut kwargs = Map::new();
@@ -547,6 +551,75 @@ async fn build_openai_compat_legacy_provider(
     }
 
     Ok(openai)
+}
+
+async fn fill_missing_kimi_model_from_env(
+    provider_env: Option<&HashMap<String, String>>,
+    model: &mut LLMModel,
+    applied: &mut HashMap<String, String>,
+) -> Result<(), LLMError> {
+    // Kimi model metadata follows the same config-first contract as provider
+    // credentials: provider.env wins over backend env, and env only fills
+    // values that are missing from config.toml.
+    if model.model.is_empty()
+        && let Some(model_name) = read_non_empty_env_override_var(
+            provider_env,
+            KIMI_MODEL_NAME_KEYS,
+            EnvLookupMode::Strict,
+        )
+        .await?
+    {
+        model.model = model_name.clone();
+        applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
+    }
+
+    if model.max_context_size <= 0
+        && let Some(max_context_size) = read_non_empty_env_override_var(
+            provider_env,
+            KIMI_MODEL_MAX_CONTEXT_SIZE_KEYS,
+            EnvLookupMode::BestEffort,
+        )
+        .await?
+    {
+        model.max_context_size = parse_env_i64(&max_context_size)?;
+        applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
+    }
+
+    if model.capabilities.is_none()
+        && let Some(caps) = read_non_empty_env_override_var(
+            provider_env,
+            KIMI_MODEL_CAPABILITIES_KEYS,
+            EnvLookupMode::BestEffort,
+        )
+        .await?
+    {
+        model.capabilities = Some(parse_model_capabilities(&caps));
+        applied.insert("KIMI_MODEL_CAPABILITIES".to_string(), caps);
+    }
+
+    Ok(())
+}
+
+fn parse_model_capabilities(caps: &str) -> HashSet<ModelCapability> {
+    let mut parsed = HashSet::new();
+    for cap in caps.split(',').map(|s| s.trim().to_lowercase()) {
+        match cap.as_str() {
+            "image_in" => {
+                parsed.insert(ModelCapability::ImageIn);
+            }
+            "video_in" => {
+                parsed.insert(ModelCapability::VideoIn);
+            }
+            "thinking" => {
+                parsed.insert(ModelCapability::Thinking);
+            }
+            "always_thinking" => {
+                parsed.insert(ModelCapability::AlwaysThinking);
+            }
+            _ => {}
+        }
+    }
+    parsed
 }
 
 fn read_host_env_var(provider_env: Option<&HashMap<String, String>>, key: &str) -> Option<String> {

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -388,6 +388,10 @@ fn parse_env_f64(value: &str) -> Result<f64, LLMError> {
 }
 
 async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
+    // Provider/model env overrides are intentionally scoped to the active backend.
+    // This keeps LLM configuration aligned with the selected kaos environment
+    // instead of the launcher process environment. Host-local bootstrap
+    // exceptions such as KIMI_SHARE_DIR live outside this module.
     kaos::env_var(key).await.map_err(|err| {
         LLMError::EnvVar(format!(
             "failed to read environment variable `{key}`: {err}"

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -33,78 +33,90 @@ impl LLM {
     }
 }
 
+#[derive(Clone, Copy)]
+struct ProviderCredentialEnvKeys {
+    base_url: &'static [&'static str],
+    api_key: &'static [&'static str],
+}
+
+struct ResolvedProviderCredentials {
+    base_url: Option<(&'static str, String)>,
+    api_key: Option<(&'static str, String)>,
+}
+
+#[derive(Clone, Copy)]
+struct OpenAiCompatEnvProfile {
+    provider_name: &'static str,
+    credentials: ProviderCredentialEnvKeys,
+    temperature: &'static [&'static str],
+}
+
 pub async fn augment_provider_with_env_vars(
     provider: &mut LLMProvider,
     model: &mut LLMModel,
 ) -> Result<HashMap<String, String>, LLMError> {
     let mut applied = HashMap::new();
+    let resolved_credentials = if let Some(env_keys) =
+        provider_credential_env_keys(&provider.provider_type)
+    {
+        Some(resolve_provider_credentials_from_env_sources(provider.env.as_ref(), env_keys).await?)
+    } else {
+        None
+    };
 
-    match provider.provider_type {
-        ProviderType::Kimi => {
-            if let Some(base_url) = read_backend_env_var("KIMI_BASE_URL")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                provider.base_url = base_url.clone();
-                applied.insert("KIMI_BASE_URL".to_string(), base_url);
+    if let Some(credentials) = resolved_credentials.as_ref() {
+        apply_resolved_provider_credentials(provider, credentials);
+        if provider.provider_type == ProviderType::Kimi {
+            if let Some((key, value)) = credentials.base_url.as_ref() {
+                applied.insert((*key).to_string(), value.clone());
             }
-            if let Some(api_key) = read_backend_env_var("KIMI_API_KEY")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                provider.api_key = api_key;
-                applied.insert("KIMI_API_KEY".to_string(), "******".to_string());
+            if let Some((key, _)) = credentials.api_key.as_ref() {
+                applied.insert((*key).to_string(), "******".to_string());
             }
-            if let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                model.model = model_name.clone();
-                applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
-            }
-            if let Some(max_context_size) = read_backend_env_var("KIMI_MODEL_MAX_CONTEXT_SIZE")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                let value = parse_env_i64(&max_context_size)?;
-                model.max_context_size = value;
-                applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
-            }
-            if let Some(caps) = read_backend_env_var("KIMI_MODEL_CAPABILITIES")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                let mut parsed = HashSet::new();
-                for cap in caps.split(',').map(|s| s.trim().to_lowercase()) {
-                    match cap.as_str() {
-                        "image_in" => {
-                            parsed.insert(ModelCapability::ImageIn);
-                        }
-                        "video_in" => {
-                            parsed.insert(ModelCapability::VideoIn);
-                        }
-                        "thinking" => {
-                            parsed.insert(ModelCapability::Thinking);
-                        }
-                        "always_thinking" => {
-                            parsed.insert(ModelCapability::AlwaysThinking);
-                        }
-                        _ => {}
+        }
+    }
+
+    if provider.provider_type == ProviderType::Kimi {
+        if let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
+            .await?
+            .filter(|value| !value.is_empty())
+        {
+            model.model = model_name.clone();
+            applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
+        }
+        if let Some(max_context_size) = read_backend_env_var("KIMI_MODEL_MAX_CONTEXT_SIZE")
+            .await?
+            .filter(|value| !value.is_empty())
+        {
+            let value = parse_env_i64(&max_context_size)?;
+            model.max_context_size = value;
+            applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
+        }
+        if let Some(caps) = read_backend_env_var("KIMI_MODEL_CAPABILITIES")
+            .await?
+            .filter(|value| !value.is_empty())
+        {
+            let mut parsed = HashSet::new();
+            for cap in caps.split(',').map(|s| s.trim().to_lowercase()) {
+                match cap.as_str() {
+                    "image_in" => {
+                        parsed.insert(ModelCapability::ImageIn);
                     }
+                    "video_in" => {
+                        parsed.insert(ModelCapability::VideoIn);
+                    }
+                    "thinking" => {
+                        parsed.insert(ModelCapability::Thinking);
+                    }
+                    "always_thinking" => {
+                        parsed.insert(ModelCapability::AlwaysThinking);
+                    }
+                    _ => {}
                 }
-                model.capabilities = Some(parsed);
-                applied.insert("KIMI_MODEL_CAPABILITIES".to_string(), caps);
             }
+            model.capabilities = Some(parsed);
+            applied.insert("KIMI_MODEL_CAPABILITIES".to_string(), caps);
         }
-        ProviderType::OpenaiLegacy | ProviderType::OpenaiResponses => {
-            apply_backend_provider_credentials(provider, "OPENAI_BASE_URL", "OPENAI_API_KEY")
-                .await?;
-        }
-        ProviderType::Anthropic => {
-            apply_backend_provider_credentials(provider, "ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY")
-                .await?;
-        }
-        _ => {}
     }
 
     Ok(applied)
@@ -168,25 +180,15 @@ pub async fn create_llm(
             }
             Box::new(kimi)
         }
-        ProviderType::OpenaiLegacy => {
-            let mut openai = kosong::chat_provider::openai_legacy::OpenAILegacy::new(
-                model.model.clone(),
-                non_empty_provider_value(&provider.api_key),
-                Some(provider.base_url.clone()),
-                Some(default_headers.clone()),
+        ProviderType::OpenaiLegacy => Box::new(
+            build_openai_compat_legacy_provider(
+                &provider.provider_type,
+                provider,
+                model,
+                default_headers.clone(),
             )
-            .map_err(map_chat_provider_error)?;
-            if let Some(value) = read_backend_env_var("OPENAI_MODEL_TEMPERATURE")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                let parsed = parse_env_f64(&value)?;
-                let mut kwargs = Map::new();
-                kwargs.insert("temperature".to_string(), Value::from(parsed));
-                openai = openai.with_generation_kwargs(kwargs);
-            }
-            Box::new(openai)
-        }
+            .await?,
+        ),
         ProviderType::OpenaiResponses => {
             let mut openai = kosong::chat_provider::openai_responses::OpenAIResponses::new(
                 model.model.clone(),
@@ -195,9 +197,11 @@ pub async fn create_llm(
                 Some(default_headers.clone()),
             )
             .map_err(map_chat_provider_error)?;
-            if let Some(value) = read_backend_env_var("OPENAI_MODEL_TEMPERATURE")
-                .await?
-                .filter(|value| !value.is_empty())
+            if let Some(value) = read_non_empty_env_override_var(
+                provider.env.as_ref(),
+                &["OPENAI_MODEL_TEMPERATURE"],
+            )
+            .await?
             {
                 let parsed = parse_env_f64(&value)?;
                 let mut kwargs = Map::new();
@@ -245,43 +249,24 @@ pub async fn create_llm(
             anthropic = anthropic.with_generation_kwargs(kwargs);
             Box::new(anthropic)
         }
-        ProviderType::GoogleGenai | ProviderType::Gemini => {
-            // Intentional: use OpenAI-compatible Gemini endpoint via OpenAILegacy for now.
-            Box::new(
-                kosong::chat_provider::openai_legacy::OpenAILegacy::new(
-                    model.model.clone(),
-                    non_empty_provider_value(&provider.api_key),
-                    Some(provider.base_url.clone()),
-                    Some(default_headers.clone()),
-                )
-                .map_err(map_chat_provider_error)?
-                .with_provider_name("google_genai"),
+        ProviderType::GoogleGenai | ProviderType::Gemini => Box::new(
+            build_openai_compat_legacy_provider(
+                &provider.provider_type,
+                provider,
+                model,
+                default_headers.clone(),
             )
-        }
-        ProviderType::Vertexai => {
-            // Intentional: use Vertex AI OpenAI-compatible endpoint via OpenAILegacy for now.
-            let api_key = resolve_provider_value_with_explicit_env(
-                &provider.api_key,
-                provider.env.as_ref(),
-                "OPENAI_API_KEY",
-            );
-            let base_url = resolve_provider_value(
-                &provider.base_url,
-                provider.env.as_ref(),
-                "OPENAI_BASE_URL",
+            .await?,
+        ),
+        ProviderType::Vertexai => Box::new(
+            build_openai_compat_legacy_provider(
+                &provider.provider_type,
+                provider,
+                model,
+                default_headers.clone(),
             )
-            .await?;
-            Box::new(
-                kosong::chat_provider::openai_legacy::OpenAILegacy::new(
-                    model.model.clone(),
-                    api_key,
-                    Some(base_url),
-                    Some(default_headers.clone()),
-                )
-                .map_err(map_chat_provider_error)?
-                .with_provider_name("vertexai"),
-            )
-        }
+            .await?,
+        ),
         ProviderType::Echo => Box::new(kosong::chat_provider::echo::EchoChatProvider),
         ProviderType::ScriptedEcho => {
             let scripts = load_scripted_echo_scripts(provider.env.as_ref()).await?;
@@ -393,24 +378,130 @@ async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
     })
 }
 
-async fn read_non_empty_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
-    Ok(read_backend_env_var(key)
+async fn read_env_override_var(
+    provider_env: Option<&HashMap<String, String>>,
+    keys: &'static [&'static str],
+) -> Result<Option<(&'static str, String)>, LLMError> {
+    for key in keys {
+        if let Some(value) = provider_env.and_then(|envs| envs.get(*key)).cloned() {
+            return Ok(Some((*key, value)));
+        }
+        if let Some(value) = read_backend_env_var(key).await?
+            && !value.is_empty()
+        {
+            return Ok(Some((*key, value)));
+        }
+    }
+    Ok(None)
+}
+
+async fn read_non_empty_env_override_var(
+    provider_env: Option<&HashMap<String, String>>,
+    keys: &'static [&'static str],
+) -> Result<Option<String>, LLMError> {
+    Ok(read_env_override_var(provider_env, keys)
         .await?
+        .map(|(_, value)| value)
         .filter(|value| !value.is_empty()))
 }
 
-async fn apply_backend_provider_credentials(
+fn provider_credential_env_keys(provider_type: &ProviderType) -> Option<ProviderCredentialEnvKeys> {
+    match provider_type {
+        ProviderType::Kimi => Some(ProviderCredentialEnvKeys {
+            base_url: &["KIMI_BASE_URL"],
+            api_key: &["KIMI_API_KEY"],
+        }),
+        ProviderType::Anthropic => Some(ProviderCredentialEnvKeys {
+            base_url: &["ANTHROPIC_BASE_URL"],
+            api_key: &["ANTHROPIC_API_KEY"],
+        }),
+        _ => openai_compat_env_profile(provider_type).map(|profile| profile.credentials),
+    }
+}
+
+fn openai_compat_env_profile(provider_type: &ProviderType) -> Option<OpenAiCompatEnvProfile> {
+    match provider_type {
+        ProviderType::OpenaiLegacy => Some(OpenAiCompatEnvProfile {
+            provider_name: "openai",
+            credentials: ProviderCredentialEnvKeys {
+                base_url: &["OPENAI_BASE_URL"],
+                api_key: &["OPENAI_API_KEY"],
+            },
+            temperature: &["OPENAI_MODEL_TEMPERATURE"],
+        }),
+        ProviderType::GoogleGenai | ProviderType::Gemini => Some(OpenAiCompatEnvProfile {
+            provider_name: "google_genai",
+            credentials: ProviderCredentialEnvKeys {
+                base_url: &["GEMINI_BASE_URL", "GOOGLE_GENAI_BASE_URL"],
+                api_key: &["GEMINI_API_KEY", "GOOGLE_GENAI_API_KEY"],
+            },
+            temperature: &["GEMINI_MODEL_TEMPERATURE", "GOOGLE_GENAI_MODEL_TEMPERATURE"],
+        }),
+        ProviderType::Vertexai => Some(OpenAiCompatEnvProfile {
+            provider_name: "vertexai",
+            credentials: ProviderCredentialEnvKeys {
+                base_url: &["VERTEXAI_BASE_URL"],
+                api_key: &["VERTEXAI_API_KEY"],
+            },
+            temperature: &["VERTEXAI_MODEL_TEMPERATURE"],
+        }),
+        _ => None,
+    }
+}
+
+async fn resolve_provider_credentials_from_env_sources(
+    provider_env: Option<&HashMap<String, String>>,
+    env_keys: ProviderCredentialEnvKeys,
+) -> Result<ResolvedProviderCredentials, LLMError> {
+    Ok(ResolvedProviderCredentials {
+        base_url: read_env_override_var(provider_env, env_keys.base_url).await?,
+        api_key: read_env_override_var(provider_env, env_keys.api_key).await?,
+    })
+}
+
+fn apply_resolved_provider_credentials(
     provider: &mut LLMProvider,
-    base_url_key: &str,
-    api_key_key: &str,
-) -> Result<(), LLMError> {
-    if let Some(base_url) = read_non_empty_backend_env_var(base_url_key).await? {
-        provider.base_url = base_url;
+    credentials: &ResolvedProviderCredentials,
+) {
+    if let Some((_, base_url)) = credentials.base_url.as_ref() {
+        provider.base_url = base_url.clone();
     }
-    if let Some(api_key) = read_non_empty_backend_env_var(api_key_key).await? {
-        provider.api_key = api_key;
+    if let Some((_, api_key)) = credentials.api_key.as_ref() {
+        provider.api_key = api_key.clone();
     }
-    Ok(())
+}
+
+async fn build_openai_compat_legacy_provider(
+    provider_type: &ProviderType,
+    provider: &LLMProvider,
+    model: &LLMModel,
+    default_headers: reqwest::header::HeaderMap,
+) -> Result<kosong::chat_provider::openai_legacy::OpenAILegacy, LLMError> {
+    let env_profile = openai_compat_env_profile(provider_type).ok_or_else(|| {
+        LLMError::ChatProvider("missing OpenAI-compatible env profile".to_string())
+    })?;
+
+    // The transport is OpenAI-compatible, but the env family stays bound to
+    // the logical provider type (OpenAI, Gemini, Vertex AI).
+    let mut openai = kosong::chat_provider::openai_legacy::OpenAILegacy::new(
+        model.model.clone(),
+        non_empty_provider_value(&provider.api_key),
+        Some(provider.base_url.clone()),
+        Some(default_headers),
+    )
+    .map_err(map_chat_provider_error)?
+    .with_provider_name(env_profile.provider_name);
+
+    if let Some(value) =
+        read_non_empty_env_override_var(provider.env.as_ref(), env_profile.temperature).await?
+    {
+        let parsed = parse_env_f64(&value)?;
+        let mut kwargs = Map::new();
+        kwargs.insert("temperature".to_string(), Value::from(parsed));
+        openai = openai.with_generation_kwargs(kwargs);
+    }
+
+    Ok(openai)
 }
 
 async fn read_env_var(
@@ -429,30 +520,6 @@ fn non_empty_provider_value(value: &str) -> Option<String> {
     } else {
         Some(value.to_string())
     }
-}
-
-async fn resolve_provider_value(
-    value: &str,
-    provider_env: Option<&HashMap<String, String>>,
-    env_key: &str,
-) -> Result<String, LLMError> {
-    if !value.is_empty() {
-        return Ok(value.to_string());
-    }
-    Ok(read_env_var(provider_env, env_key)
-        .await?
-        .unwrap_or_default())
-}
-
-fn resolve_provider_value_with_explicit_env(
-    value: &str,
-    provider_env: Option<&HashMap<String, String>>,
-    env_key: &str,
-) -> Option<String> {
-    if !value.is_empty() {
-        return Some(value.to_string());
-    }
-    provider_env.and_then(|envs| envs.get(env_key)).cloned()
 }
 
 async fn load_scripted_echo_scripts(

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -65,8 +65,17 @@ pub async fn augment_provider_with_env_vars(
     let missing_provider_api_key = provider.api_key.is_empty();
     let resolved_credentials = if let Some(env_keys) =
         provider_credential_env_keys(&provider.provider_type)
+        && (missing_provider_base_url || missing_provider_api_key)
     {
-        Some(resolve_provider_credentials_from_env_sources(provider.env.as_ref(), env_keys).await?)
+        Some(
+            resolve_provider_credentials_from_env_sources(
+                provider.env.as_ref(),
+                env_keys,
+                missing_provider_base_url,
+                missing_provider_api_key,
+            )
+            .await?,
+        )
     } else {
         None
     };
@@ -87,25 +96,26 @@ pub async fn augment_provider_with_env_vars(
         // Kimi model metadata follows the same config-first contract as
         // provider credentials: backend env supplies defaults, not overrides.
         if model.model.is_empty()
-            && let Some(model_name) = read_backend_env_var("KIMI_MODEL_NAME")
-                .await?
+            && let Some(model_name) = read_backend_env_var_best_effort("KIMI_MODEL_NAME")
+                .await
                 .filter(|value| !value.is_empty())
         {
             model.model = model_name.clone();
             applied.insert("KIMI_MODEL_NAME".to_string(), model_name);
         }
         if model.max_context_size <= 0
-            && let Some(max_context_size) = read_backend_env_var("KIMI_MODEL_MAX_CONTEXT_SIZE")
-                .await?
-                .filter(|value| !value.is_empty())
+            && let Some(max_context_size) =
+                read_backend_env_var_best_effort("KIMI_MODEL_MAX_CONTEXT_SIZE")
+                    .await
+                    .filter(|value| !value.is_empty())
         {
             let value = parse_env_i64(&max_context_size)?;
             model.max_context_size = value;
             applied.insert("KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(), max_context_size);
         }
         if model.capabilities.is_none()
-            && let Some(caps) = read_backend_env_var("KIMI_MODEL_CAPABILITIES")
-                .await?
+            && let Some(caps) = read_backend_env_var_best_effort("KIMI_MODEL_CAPABILITIES")
+                .await
                 .filter(|value| !value.is_empty())
         {
             let mut parsed = HashSet::new();
@@ -166,22 +176,22 @@ pub async fn create_llm(
                     Value::String(session_id.to_string()),
                 );
             }
-            if let Some(value) = read_backend_env_var("KIMI_MODEL_TEMPERATURE")
-                .await?
+            if let Some(value) = read_backend_env_var_best_effort("KIMI_MODEL_TEMPERATURE")
+                .await
                 .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_f64(&value)?;
                 kwargs.insert("temperature".to_string(), Value::from(parsed));
             }
-            if let Some(value) = read_backend_env_var("KIMI_MODEL_TOP_P")
-                .await?
+            if let Some(value) = read_backend_env_var_best_effort("KIMI_MODEL_TOP_P")
+                .await
                 .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_f64(&value)?;
                 kwargs.insert("top_p".to_string(), Value::from(parsed));
             }
-            if let Some(value) = read_backend_env_var("KIMI_MODEL_MAX_TOKENS")
-                .await?
+            if let Some(value) = read_backend_env_var_best_effort("KIMI_MODEL_MAX_TOKENS")
+                .await
                 .filter(|value| !value.is_empty())
             {
                 let parsed = parse_env_i64(&value)?;
@@ -209,11 +219,11 @@ pub async fn create_llm(
                 Some(default_headers.clone()),
             )
             .map_err(map_chat_provider_error)?;
-            if let Some(value) = read_non_empty_env_override_var(
+            if let Some(value) = read_non_empty_env_override_var_best_effort(
                 provider.env.as_ref(),
                 &["OPENAI_MODEL_TEMPERATURE"],
             )
-            .await?
+            .await
             {
                 let parsed = parse_env_f64(&value)?;
                 let mut kwargs = Map::new();
@@ -233,8 +243,8 @@ pub async fn create_llm(
 
             let mut kwargs = Map::new();
             kwargs.insert("max_tokens".to_string(), Value::from(50_000));
-            if let Some(value) = read_backend_env_var("ANTHROPIC_MODEL_TEMPERATURE")
-                .await?
+            if let Some(value) = read_backend_env_var_best_effort("ANTHROPIC_MODEL_TEMPERATURE")
+                .await
                 .filter(|value| !value.is_empty())
             {
                 kwargs.insert(
@@ -242,14 +252,14 @@ pub async fn create_llm(
                     Value::from(parse_env_f64(&value)?),
                 );
             }
-            if let Some(value) = read_backend_env_var("ANTHROPIC_MODEL_TOP_P")
-                .await?
+            if let Some(value) = read_backend_env_var_best_effort("ANTHROPIC_MODEL_TOP_P")
+                .await
                 .filter(|value| !value.is_empty())
             {
                 kwargs.insert("top_p".to_string(), Value::from(parse_env_f64(&value)?));
             }
-            if let Some(value) = read_backend_env_var("ANTHROPIC_MODEL_MAX_TOKENS")
-                .await?
+            if let Some(value) = read_backend_env_var_best_effort("ANTHROPIC_MODEL_MAX_TOKENS")
+                .await
                 .filter(|value| !value.is_empty())
             {
                 kwargs.insert(
@@ -390,31 +400,35 @@ async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
     })
 }
 
-async fn read_env_override_var(
-    provider_env: Option<&HashMap<String, String>>,
-    keys: &'static [&'static str],
-) -> Result<Option<(&'static str, String)>, LLMError> {
-    for key in keys {
-        if let Some(value) = provider_env.and_then(|envs| envs.get(*key)).cloned() {
-            return Ok(Some((*key, value)));
-        }
-        if let Some(value) = read_backend_env_var(key).await?
-            && !value.is_empty()
-        {
-            return Ok(Some((*key, value)));
-        }
-    }
-    Ok(None)
+async fn read_backend_env_var_best_effort(key: &str) -> Option<String> {
+    read_backend_env_var(key).await.unwrap_or_default()
 }
 
-async fn read_non_empty_env_override_var(
+async fn read_env_override_var_best_effort(
     provider_env: Option<&HashMap<String, String>>,
     keys: &'static [&'static str],
-) -> Result<Option<String>, LLMError> {
-    Ok(read_env_override_var(provider_env, keys)
-        .await?
+) -> Option<(&'static str, String)> {
+    for key in keys {
+        if let Some(value) = provider_env.and_then(|envs| envs.get(*key)).cloned() {
+            return Some((*key, value));
+        }
+        if let Some(value) = read_backend_env_var_best_effort(key).await
+            && !value.is_empty()
+        {
+            return Some((*key, value));
+        }
+    }
+    None
+}
+
+async fn read_non_empty_env_override_var_best_effort(
+    provider_env: Option<&HashMap<String, String>>,
+    keys: &'static [&'static str],
+) -> Option<String> {
+    read_env_override_var_best_effort(provider_env, keys)
+        .await
         .map(|(_, value)| value)
-        .filter(|value| !value.is_empty()))
+        .filter(|value| !value.is_empty())
 }
 
 fn provider_credential_env_keys(provider_type: &ProviderType) -> Option<ProviderCredentialEnvKeys> {
@@ -466,10 +480,20 @@ fn openai_compat_env_profile(provider_type: &ProviderType) -> Option<OpenAiCompa
 async fn resolve_provider_credentials_from_env_sources(
     provider_env: Option<&HashMap<String, String>>,
     env_keys: ProviderCredentialEnvKeys,
+    resolve_base_url: bool,
+    resolve_api_key: bool,
 ) -> Result<ResolvedProviderCredentials, LLMError> {
     Ok(ResolvedProviderCredentials {
-        base_url: read_env_override_var(provider_env, env_keys.base_url).await?,
-        api_key: read_env_override_var(provider_env, env_keys.api_key).await?,
+        base_url: if resolve_base_url {
+            read_env_override_var_best_effort(provider_env, env_keys.base_url).await
+        } else {
+            None
+        },
+        api_key: if resolve_api_key {
+            read_env_override_var_best_effort(provider_env, env_keys.api_key).await
+        } else {
+            None
+        },
     })
 }
 
@@ -513,7 +537,8 @@ async fn build_openai_compat_legacy_provider(
     .with_provider_name(env_profile.provider_name);
 
     if let Some(value) =
-        read_non_empty_env_override_var(provider.env.as_ref(), env_profile.temperature).await?
+        read_non_empty_env_override_var_best_effort(provider.env.as_ref(), env_profile.temperature)
+            .await
     {
         let parsed = parse_env_f64(&value)?;
         let mut kwargs = Map::new();

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -97,18 +97,12 @@ pub async fn augment_provider_with_env_vars(
             }
         }
         ProviderType::OpenaiLegacy | ProviderType::OpenaiResponses => {
-            if let Some(base_url) = read_backend_env_var("OPENAI_BASE_URL")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                provider.base_url = base_url;
-            }
-            if let Some(api_key) = read_backend_env_var("OPENAI_API_KEY")
-                .await?
-                .filter(|value| !value.is_empty())
-            {
-                provider.api_key = api_key;
-            }
+            apply_backend_provider_credentials(provider, "OPENAI_BASE_URL", "OPENAI_API_KEY")
+                .await?;
+        }
+        ProviderType::Anthropic => {
+            apply_backend_provider_credentials(provider, "ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY")
+                .await?;
         }
         _ => {}
     }
@@ -397,6 +391,26 @@ async fn read_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
             "failed to read environment variable `{key}`: {err}"
         ))
     })
+}
+
+async fn read_non_empty_backend_env_var(key: &str) -> Result<Option<String>, LLMError> {
+    Ok(read_backend_env_var(key)
+        .await?
+        .filter(|value| !value.is_empty()))
+}
+
+async fn apply_backend_provider_credentials(
+    provider: &mut LLMProvider,
+    base_url_key: &str,
+    api_key_key: &str,
+) -> Result<(), LLMError> {
+    if let Some(base_url) = read_non_empty_backend_env_var(base_url_key).await? {
+        provider.base_url = base_url;
+    }
+    if let Some(api_key) = read_non_empty_backend_env_var(api_key_key).await? {
+        provider.api_key = api_key;
+    }
+    Ok(())
 }
 
 async fn read_env_var(

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -422,14 +422,16 @@ fn provider_credential_env_keys(provider_type: &ProviderType) -> Option<Provider
 
 fn openai_compat_env_profile(provider_type: &ProviderType) -> Option<OpenAiCompatEnvProfile> {
     match provider_type {
-        ProviderType::OpenaiLegacy => Some(OpenAiCompatEnvProfile {
-            provider_name: "openai",
-            credentials: ProviderCredentialEnvKeys {
-                base_url: &["OPENAI_BASE_URL"],
-                api_key: &["OPENAI_API_KEY"],
-            },
-            temperature: &["OPENAI_MODEL_TEMPERATURE"],
-        }),
+        ProviderType::OpenaiLegacy | ProviderType::OpenaiResponses => {
+            Some(OpenAiCompatEnvProfile {
+                provider_name: "openai",
+                credentials: ProviderCredentialEnvKeys {
+                    base_url: &["OPENAI_BASE_URL"],
+                    api_key: &["OPENAI_API_KEY"],
+                },
+                temperature: &["OPENAI_MODEL_TEMPERATURE"],
+            })
+        }
         ProviderType::GoogleGenai | ProviderType::Gemini => Some(OpenAiCompatEnvProfile {
             provider_name: "google_genai",
             credentials: ProviderCredentialEnvKeys {

--- a/kimi-agent/src/llm.rs
+++ b/kimi-agent/src/llm.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::env;
 use std::path::PathBuf;
 
 use serde_json::{Map, Value};
@@ -270,8 +271,8 @@ pub async fn create_llm(
         ProviderType::Echo => Box::new(kosong::chat_provider::echo::EchoChatProvider),
         ProviderType::ScriptedEcho => {
             let scripts = load_scripted_echo_scripts(provider.env.as_ref()).await?;
-            let trace = read_env_var(provider.env.as_ref(), "KIMI_SCRIPTED_ECHO_TRACE")
-                .await?
+            // Scripted echo scripts and tracing are host-local test fixtures.
+            let trace = read_host_env_var(provider.env.as_ref(), "KIMI_SCRIPTED_ECHO_TRACE")
                 .unwrap_or_default()
                 .trim()
                 .to_lowercase();
@@ -504,14 +505,11 @@ async fn build_openai_compat_legacy_provider(
     Ok(openai)
 }
 
-async fn read_env_var(
-    provider_env: Option<&HashMap<String, String>>,
-    key: &str,
-) -> Result<Option<String>, LLMError> {
-    if let Some(value) = provider_env.and_then(|envs| envs.get(key)).cloned() {
-        return Ok(Some(value));
-    }
-    read_backend_env_var(key).await
+fn read_host_env_var(provider_env: Option<&HashMap<String, String>>, key: &str) -> Option<String> {
+    provider_env
+        .and_then(|envs| envs.get(key))
+        .cloned()
+        .or_else(|| env::var(key).ok())
 }
 
 fn non_empty_provider_value(value: &str) -> Option<String> {
@@ -525,9 +523,8 @@ fn non_empty_provider_value(value: &str) -> Option<String> {
 async fn load_scripted_echo_scripts(
     provider_env: Option<&HashMap<String, String>>,
 ) -> Result<Vec<String>, LLMError> {
-    let script_path = read_env_var(provider_env, "KIMI_SCRIPTED_ECHO_SCRIPTS")
-        .await?
-        .ok_or_else(|| {
+    let script_path =
+        read_host_env_var(provider_env, "KIMI_SCRIPTED_ECHO_SCRIPTS").ok_or_else(|| {
             LLMError::ScriptedEcho(
                 "KIMI_SCRIPTED_ECHO_SCRIPTS is required for _scripted_echo.".to_string(),
             )

--- a/kimi-agent/src/soul/toolset.rs
+++ b/kimi-agent/src/soul/toolset.rs
@@ -228,7 +228,7 @@ impl KimiToolset {
                     }
                 }
 
-                if std::env::var("KIMI_TEST_TRACE").as_deref() == Ok("1") {
+                if backend_test_trace_enabled().await {
                     eprintln!("MCP config loaded server: {name}");
                 }
                 self.mcp_servers
@@ -251,7 +251,7 @@ impl KimiToolset {
         let task = tokio::spawn(async move {
             let mut failures: HashMap<String, String> = HashMap::new();
             for name in servers_to_connect {
-                if std::env::var("KIMI_TEST_TRACE").as_deref() == Ok("1") {
+                if backend_test_trace_enabled().await {
                     eprintln!("MCP connecting to server: {name}");
                 }
                 if let Err(err) = connect_mcp_server(&toolset_ref, &runtime, &name).await {
@@ -326,6 +326,10 @@ impl Default for KimiToolset {
     fn default() -> Self {
         Self::new()
     }
+}
+
+async fn backend_test_trace_enabled() -> bool {
+    matches!(kaos::env_var("KIMI_TEST_TRACE").await, Ok(Some(value)) if value == "1")
 }
 
 impl Toolset for KimiToolset {
@@ -745,7 +749,7 @@ async fn connect_mcp_server(
                 "Failed to connect MCP server: {}, error: {}",
                 server_name, err
             );
-            if std::env::var("KIMI_TEST_TRACE").as_deref() == Ok("1") {
+            if backend_test_trace_enabled().await {
                 eprintln!("MCP connect error for {server_name}: {err}");
             }
             return Err(MCPRuntimeError::new(err));
@@ -762,13 +766,13 @@ async fn connect_mcp_server(
                 info.status = McpServerStatus::Failed;
                 info.last_error = Some(err.to_string());
             }
-            if std::env::var("KIMI_TEST_TRACE").as_deref() == Ok("1") {
+            if backend_test_trace_enabled().await {
                 eprintln!("MCP list tools error for {server_name}: {err}");
             }
             return Err(MCPRuntimeError::new(err.to_string()));
         }
     };
-    if std::env::var("KIMI_TEST_TRACE").as_deref() == Ok("1") {
+    if backend_test_trace_enabled().await {
         eprintln!("MCP server {server_name} listed {} tools", tools.len());
     }
 

--- a/kimi-agent/src/tools/shell.rs
+++ b/kimi-agent/src/tools/shell.rs
@@ -17,7 +17,7 @@ const POWERSHELL_DESC: &str = include_str!("desc/shell/powershell.md");
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ShellParams {
-    #[schemars(description = "The bash command to execute.")]
+    #[schemars(description = "The shell command to execute.")]
     pub command: String,
     #[serde(default = "default_timeout")]
     #[schemars(

--- a/kimi-agent/src/utils/environment.rs
+++ b/kimi-agent/src/utils/environment.rs
@@ -56,7 +56,7 @@ async fn detect_unix_shell() -> (String, KaosPath) {
 
     for (name, candidate) in unix_shell_candidates() {
         let path = KaosPath::new(candidate);
-        if path.is_file(true).await {
+        if is_executable_unix_shell(&path).await {
             return (name.to_string(), path);
         }
     }
@@ -79,7 +79,7 @@ async fn shell_from_backend_env() -> Option<(String, KaosPath)> {
         "zsh" => "zsh",
         _ => return None,
     };
-    if !path.is_file(true).await {
+    if !is_executable_unix_shell(&path).await {
         return None;
     }
 
@@ -95,4 +95,16 @@ fn unix_shell_candidates() -> [(&'static str, &'static str); 6] {
         ("zsh", "/usr/bin/zsh"),
         ("zsh", "/usr/local/bin/zsh"),
     ]
+}
+
+async fn is_executable_unix_shell(path: &KaosPath) -> bool {
+    let Ok(stat) = path.stat(true).await else {
+        return false;
+    };
+
+    is_regular_file(stat.st_mode) && stat.st_mode & 0o111 != 0
+}
+
+fn is_regular_file(mode: u32) -> bool {
+    mode & 0o170000 == 0o100000
 }

--- a/kimi-agent/src/utils/environment.rs
+++ b/kimi-agent/src/utils/environment.rs
@@ -37,26 +37,7 @@ impl Environment {
             };
         }
 
-        if let Some(shell) = shell_from_backend_env().await {
-            return Environment {
-                os_kind,
-                os_arch,
-                os_version,
-                shell_name: shell.0,
-                shell_path: shell.1,
-            };
-        }
-
-        let mut shell_name = "sh".to_string();
-        let mut shell_path = KaosPath::new("/bin/sh");
-        for candidate in ["/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"] {
-            let path = KaosPath::new(candidate);
-            if path.is_file(true).await {
-                shell_name = "bash".to_string();
-                shell_path = path;
-                break;
-            }
-        }
+        let (shell_name, shell_path) = detect_unix_shell().await;
 
         Environment {
             os_kind,
@@ -68,6 +49,21 @@ impl Environment {
     }
 }
 
+async fn detect_unix_shell() -> (String, KaosPath) {
+    if let Some(shell) = shell_from_backend_env().await {
+        return shell;
+    }
+
+    for (name, candidate) in unix_shell_candidates() {
+        let path = KaosPath::new(candidate);
+        if path.is_file(true).await {
+            return (name.to_string(), path);
+        }
+    }
+
+    ("sh".to_string(), KaosPath::new("/bin/sh"))
+}
+
 async fn shell_from_backend_env() -> Option<(String, KaosPath)> {
     let shell = kaos::env_var("SHELL").await.ok().flatten()?;
     if shell.is_empty() {
@@ -76,9 +72,11 @@ async fn shell_from_backend_env() -> Option<(String, KaosPath)> {
 
     let path = KaosPath::new(shell);
     let basename = path.name().to_ascii_lowercase();
+    // Respect explicit bash/zsh shells from the backend environment, but do not let
+    // `SHELL=/bin/sh` override our stronger bash/zsh fallback preference.
     let name = match basename.as_str() {
         "bash" => "bash",
-        "sh" => "sh",
+        "zsh" => "zsh",
         _ => return None,
     };
     if !path.is_file(true).await {
@@ -86,4 +84,15 @@ async fn shell_from_backend_env() -> Option<(String, KaosPath)> {
     }
 
     Some((name.to_string(), path))
+}
+
+fn unix_shell_candidates() -> [(&'static str, &'static str); 6] {
+    [
+        ("bash", "/bin/bash"),
+        ("bash", "/usr/bin/bash"),
+        ("bash", "/usr/local/bin/bash"),
+        ("zsh", "/bin/zsh"),
+        ("zsh", "/usr/bin/zsh"),
+        ("zsh", "/usr/local/bin/zsh"),
+    ]
 }

--- a/kimi-agent/src/utils/environment.rs
+++ b/kimi-agent/src/utils/environment.rs
@@ -37,6 +37,16 @@ impl Environment {
             };
         }
 
+        if let Some(shell) = shell_from_backend_env().await {
+            return Environment {
+                os_kind,
+                os_arch,
+                os_version,
+                shell_name: shell.0,
+                shell_path: shell.1,
+            };
+        }
+
         let mut shell_name = "sh".to_string();
         let mut shell_path = KaosPath::new("/bin/sh");
         for candidate in ["/bin/bash", "/usr/bin/bash", "/usr/local/bin/bash"] {
@@ -56,4 +66,24 @@ impl Environment {
             shell_path,
         }
     }
+}
+
+async fn shell_from_backend_env() -> Option<(String, KaosPath)> {
+    let shell = kaos::env_var("SHELL").await.ok().flatten()?;
+    if shell.is_empty() {
+        return None;
+    }
+
+    let path = KaosPath::new(shell);
+    let basename = path.name().to_ascii_lowercase();
+    let name = match basename.as_str() {
+        "bash" => "bash",
+        "sh" => "sh",
+        _ => return None,
+    };
+    if !path.is_file(true).await {
+        return None;
+    }
+
+    Some((name.to_string(), path))
 }

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -298,6 +298,50 @@ async fn test_augment_provider_with_env_vars_anthropic_uses_backend_env() {
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_google_genai_uses_gemini_env_family() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "GEMINI_BASE_URL".to_string(),
+                "https://backend.gemini.test/v1beta/openai".to_string(),
+            ),
+            (
+                "GEMINI_API_KEY".to_string(),
+                "backend-gemini-key".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::GoogleGenai,
+            base_url: String::new(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "google".to_string(),
+            model: "gemini-2.5-flash".to_string(),
+            max_context_size: 1_000_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(
+            provider.base_url,
+            "https://backend.gemini.test/v1beta/openai"
+        );
+        assert_eq!(provider.api_key, "backend-gemini-key");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_uses_backend_env_without_process_fallback() {
     let _lock = ENV_LOCK.lock().await;
     let _guards = [
@@ -339,13 +383,10 @@ async fn test_augment_provider_with_env_vars_prefers_provider_env_over_backend_e
     let mock_server = MockServer::start().await;
 
     with_current_kaos_scope(async {
-        let _guard = BackendEnvKaosGuard::new(HashMap::from([
-            (
-                "OPENAI_BASE_URL".to_string(),
-                "https://backend.invalid/v1".to_string(),
-            ),
-            ("OPENAI_API_KEY".to_string(), "backend-key".to_string()),
-        ]));
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([(
+            "VERTEXAI_API_KEY".to_string(),
+            "backend-key".to_string(),
+        )]));
 
         let base_url = format!("{}/v1", mock_server.uri());
         let api_key = "provider-key".to_string();
@@ -358,29 +399,31 @@ async fn test_augment_provider_with_env_vars_prefers_provider_env_over_backend_e
             .mount(&mock_server)
             .await;
 
-        let llm = create_llm(
-            &LLMProvider {
-                provider_type: ProviderType::Vertexai,
-                base_url: base_url.clone(),
-                api_key: String::new(),
-                env: Some(HashMap::from([(
-                    "OPENAI_API_KEY".to_string(),
-                    api_key.clone(),
-                )])),
-                custom_headers: None,
-            },
-            &LLMModel {
-                provider: "vertex".to_string(),
-                model: "gemini-3-pro-preview".to_string(),
-                max_context_size: 1_000_000,
-                capabilities: None,
-            },
-            None,
-            None,
-        )
-        .await
-        .expect("create llm")
-        .expect("llm");
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Vertexai,
+            base_url: base_url.clone(),
+            api_key: String::new(),
+            env: Some(HashMap::from([(
+                "VERTEXAI_API_KEY".to_string(),
+                api_key.clone(),
+            )])),
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "vertex".to_string(),
+            model: "gemini-3-pro-preview".to_string(),
+            max_context_size: 1_000_000,
+            capabilities: None,
+        };
+
+        augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        let llm = create_llm(&provider, &model, None, None)
+            .await
+            .expect("create llm")
+            .expect("llm");
 
         let tools: Vec<kosong::tooling::Tool> = vec![];
         let history: Vec<kosong::message::Message> = vec![];
@@ -615,6 +658,52 @@ async fn test_create_llm_google_genai_provider_uses_openai_compat() {
 }
 
 #[tokio::test]
+async fn test_create_llm_google_genai_uses_gemini_temperature_env() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([(
+            "GEMINI_MODEL_TEMPERATURE".to_string(),
+            "0.3".to_string(),
+        )]));
+
+        let provider = LLMProvider {
+            provider_type: ProviderType::GoogleGenai,
+            base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
+            api_key: "test-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let model = LLMModel {
+            provider: "google".to_string(),
+            model: "gemini-2.5-flash".to_string(),
+            max_context_size: 1_000_000,
+            capabilities: None,
+        };
+
+        let llm = create_llm(&provider, &model, None, None)
+            .await
+            .expect("create llm")
+            .expect("llm");
+
+        let openai = llm
+            .chat_provider
+            .as_any()
+            .downcast_ref::<OpenAILegacy>()
+            .expect("openai legacy provider");
+
+        assert_eq!(
+            serde_json::Value::Object(openai.model_parameters()),
+            json!({
+                "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",
+                "temperature": 0.3
+            })
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_create_llm_vertexai_provider_does_not_mutate_process_env_and_uses_openai_compat() {
     let _lock = ENV_LOCK.lock().await;
     let _guard = EnvGuard::set("VERTEX_TEST_PROJECT", "old");
@@ -691,9 +780,9 @@ async fn test_create_llm_scripted_echo_prefers_provider_env_without_mutating_pro
 }
 
 #[tokio::test]
-async fn test_create_llm_vertexai_uses_provider_env_openai_api_key_without_mutating_process_env() {
+async fn test_create_llm_vertexai_uses_provider_scoped_api_key_env_without_mutating_process_env() {
     let _lock = ENV_LOCK.lock().await;
-    let _guard = EnvGuard::set("OPENAI_API_KEY", "process-old-key");
+    let _guard = EnvGuard::set("VERTEXAI_API_KEY", "process-old-key");
     let mock_server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -704,22 +793,26 @@ async fn test_create_llm_vertexai_uses_provider_env_openai_api_key_without_mutat
         .mount(&mock_server)
         .await;
 
-    let provider = LLMProvider {
+    let mut provider = LLMProvider {
         provider_type: ProviderType::Vertexai,
         base_url: format!("{}/v1", mock_server.uri()),
         api_key: String::new(),
         env: Some(HashMap::from([(
-            "OPENAI_API_KEY".to_string(),
+            "VERTEXAI_API_KEY".to_string(),
             "overlay-key".to_string(),
         )])),
         custom_headers: None,
     };
-    let model = LLMModel {
+    let mut model = LLMModel {
         provider: "vertex".to_string(),
         model: "gemini-3-pro-preview".to_string(),
         max_context_size: 1_000_000,
         capabilities: None,
     };
+
+    augment_provider_with_env_vars(&mut provider, &mut model)
+        .await
+        .expect("env overrides");
 
     let llm = create_llm(&provider, &model, None, None)
         .await
@@ -737,7 +830,7 @@ async fn test_create_llm_vertexai_uses_provider_env_openai_api_key_without_mutat
         .expect("generate request should use provider env api key");
 
     assert_eq!(
-        std::env::var("OPENAI_API_KEY").expect("openai env"),
+        std::env::var("VERTEXAI_API_KEY").expect("vertex env"),
         "process-old-key"
     );
 }
@@ -746,7 +839,7 @@ async fn test_create_llm_vertexai_uses_provider_env_openai_api_key_without_mutat
 async fn test_create_llm_vertexai_explicit_empty_provider_env_api_key_disables_process_env_fallback()
  {
     let _lock = ENV_LOCK.lock().await;
-    let _guard = EnvGuard::set("OPENAI_API_KEY", "process-old-key");
+    let _guard = EnvGuard::set("VERTEXAI_API_KEY", "process-old-key");
     let mock_server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -763,22 +856,26 @@ async fn test_create_llm_vertexai_explicit_empty_provider_env_api_key_disables_p
         .mount(&mock_server)
         .await;
 
-    let provider = LLMProvider {
+    let mut provider = LLMProvider {
         provider_type: ProviderType::Vertexai,
         base_url: format!("{}/v1", mock_server.uri()),
         api_key: String::new(),
         env: Some(HashMap::from([(
-            "OPENAI_API_KEY".to_string(),
+            "VERTEXAI_API_KEY".to_string(),
             String::new(),
         )])),
         custom_headers: None,
     };
-    let model = LLMModel {
+    let mut model = LLMModel {
         provider: "vertex".to_string(),
         model: "gemini-3-pro-preview".to_string(),
         max_context_size: 1_000_000,
         capabilities: None,
     };
+
+    augment_provider_with_env_vars(&mut provider, &mut model)
+        .await
+        .expect("env overrides");
 
     let llm = create_llm(&provider, &model, None, None)
         .await
@@ -793,10 +890,10 @@ async fn test_create_llm_vertexai_explicit_empty_provider_env_api_key_disables_p
         .chat_provider
         .generate("", &tools, &history)
         .await
-        .expect("generate request should not fall back to process openai key");
+        .expect("generate request should not fall back to process vertex key");
 
     assert_eq!(
-        std::env::var("OPENAI_API_KEY").expect("openai env"),
+        std::env::var("VERTEXAI_API_KEY").expect("vertex env"),
         "process-old-key"
     );
 }

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -257,6 +257,47 @@ async fn test_augment_provider_with_env_vars_invalid_max_context_size() {
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_anthropic_uses_backend_env() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "ANTHROPIC_BASE_URL".to_string(),
+                "https://backend.anthropic.test".to_string(),
+            ),
+            (
+                "ANTHROPIC_API_KEY".to_string(),
+                "backend-anthropic-key".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Anthropic,
+            base_url: String::new(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4".to_string(),
+            max_context_size: 200_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(provider.base_url, "https://backend.anthropic.test");
+        assert_eq!(provider.api_key, "backend-anthropic-key");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_uses_backend_env_without_process_fallback() {
     let _lock = ENV_LOCK.lock().await;
     let _guards = [

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -307,6 +307,70 @@ async fn test_augment_provider_with_env_vars_invalid_max_context_size() {
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_kimi_prefers_provider_env_for_model_defaults() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "KIMI_MODEL_NAME".to_string(),
+                "kimi-backend-model".to_string(),
+            ),
+            (
+                "KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(),
+                "8192".to_string(),
+            ),
+            (
+                "KIMI_MODEL_CAPABILITIES".to_string(),
+                "image_in".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Kimi,
+            base_url: "https://configured.test/v1".to_string(),
+            api_key: "configured-key".to_string(),
+            env: Some(HashMap::from([
+                (
+                    "KIMI_MODEL_NAME".to_string(),
+                    "kimi-provider-model".to_string(),
+                ),
+                (
+                    "KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(),
+                    "4096".to_string(),
+                ),
+                (
+                    "KIMI_MODEL_CAPABILITIES".to_string(),
+                    "video_in,thinking".to_string(),
+                ),
+            ])),
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "kimi".to_string(),
+            model: String::new(),
+            max_context_size: 0,
+            capabilities: None,
+        };
+
+        augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("provider env should win");
+
+        assert_eq!(model.model, "kimi-provider-model");
+        assert_eq!(model.max_context_size, 4096);
+        assert_eq!(
+            model.capabilities,
+            Some(HashSet::from([
+                ModelCapability::VideoIn,
+                ModelCapability::Thinking,
+            ]))
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_anthropic_uses_backend_env() {
     let _lock = ENV_LOCK.lock().await;
 
@@ -422,6 +486,39 @@ async fn test_augment_provider_with_env_vars_skips_backend_probe_for_explicit_cr
         assert!(applied.is_empty());
         assert_eq!(provider.base_url, "https://configured.anthropic.test");
         assert_eq!(provider.api_key, "configured-anthropic-key");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_errors_when_required_backend_credential_lookup_fails()
+{
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::with_failing_keys(
+            HashMap::new(),
+            HashSet::from(["ANTHROPIC_API_KEY".to_string()]),
+        );
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Anthropic,
+            base_url: "https://configured.anthropic.test".to_string(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4".to_string(),
+            max_context_size: 200_000,
+            capabilities: None,
+        };
+
+        let err = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect_err("missing credential lookup should stay strict");
+        assert!(err.to_string().contains("backend env lookup failed"));
     })
     .await;
 }
@@ -737,6 +834,59 @@ async fn test_create_llm_kimi_model_parameters() {
 }
 
 #[tokio::test]
+async fn test_create_llm_kimi_prefers_provider_env_for_model_parameters() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            ("KIMI_MODEL_TEMPERATURE".to_string(), "0.7".to_string()),
+            ("KIMI_MODEL_TOP_P".to_string(), "0.9".to_string()),
+            ("KIMI_MODEL_MAX_TOKENS".to_string(), "9999".to_string()),
+        ]));
+
+        let provider = LLMProvider {
+            provider_type: ProviderType::Kimi,
+            base_url: "https://api.test/v1".to_string(),
+            api_key: "test-key".to_string(),
+            env: Some(HashMap::from([
+                ("KIMI_MODEL_TEMPERATURE".to_string(), "0.2".to_string()),
+                ("KIMI_MODEL_TOP_P".to_string(), "0.8".to_string()),
+                ("KIMI_MODEL_MAX_TOKENS".to_string(), "1234".to_string()),
+            ])),
+            custom_headers: None,
+        };
+        let model = LLMModel {
+            provider: "kimi".to_string(),
+            model: "kimi-base".to_string(),
+            max_context_size: 4096,
+            capabilities: None,
+        };
+
+        let llm = create_llm(&provider, &model, None, None)
+            .await
+            .expect("create llm")
+            .expect("llm");
+
+        let kimi = llm
+            .chat_provider
+            .as_any()
+            .downcast_ref::<Kimi>()
+            .expect("kimi provider");
+
+        assert_eq!(
+            serde_json::Value::Object(kimi.model_parameters()),
+            json!({
+                "base_url": "https://api.test/v1/",
+                "temperature": 0.2,
+                "top_p": 0.8,
+                "max_tokens": 1234
+            })
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_create_llm_invalid_temperature_env() {
     let _lock = ENV_LOCK.lock().await;
     let _guard = EnvGuard::set("KIMI_MODEL_TEMPERATURE", "not-a-number");
@@ -958,6 +1108,54 @@ async fn test_create_llm_anthropic_provider() {
 
     assert!(llm.chat_provider.as_any().is::<Anthropic>());
     assert_eq!(llm.chat_provider.name(), "anthropic");
+}
+
+#[tokio::test]
+async fn test_create_llm_anthropic_prefers_provider_env_for_model_parameters() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            ("ANTHROPIC_MODEL_TEMPERATURE".to_string(), "0.7".to_string()),
+            ("ANTHROPIC_MODEL_TOP_P".to_string(), "0.9".to_string()),
+            ("ANTHROPIC_MODEL_MAX_TOKENS".to_string(), "9999".to_string()),
+        ]));
+
+        let provider = LLMProvider {
+            provider_type: ProviderType::Anthropic,
+            base_url: "https://api.anthropic.test".to_string(),
+            api_key: "test-key".to_string(),
+            env: Some(HashMap::from([
+                ("ANTHROPIC_MODEL_TEMPERATURE".to_string(), "0.2".to_string()),
+                ("ANTHROPIC_MODEL_TOP_P".to_string(), "0.8".to_string()),
+                ("ANTHROPIC_MODEL_MAX_TOKENS".to_string(), "1234".to_string()),
+            ])),
+            custom_headers: None,
+        };
+        let model = LLMModel {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4".to_string(),
+            max_context_size: 200_000,
+            capabilities: None,
+        };
+
+        let llm = create_llm(&provider, &model, None, None)
+            .await
+            .expect("create llm")
+            .expect("llm");
+
+        let anthropic = llm
+            .chat_provider
+            .as_any()
+            .downcast_ref::<Anthropic>()
+            .expect("anthropic provider");
+        let params = anthropic.model_parameters();
+
+        assert_eq!(params.get("temperature"), Some(&json!(0.2)));
+        assert_eq!(params.get("top_p"), Some(&json!(0.8)));
+        assert_eq!(params.get("max_tokens"), Some(&json!(1234)));
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -342,6 +342,47 @@ async fn test_augment_provider_with_env_vars_google_genai_uses_gemini_env_family
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_openai_responses_uses_openai_env_family() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "OPENAI_BASE_URL".to_string(),
+                "https://backend.openai.test/v1".to_string(),
+            ),
+            (
+                "OPENAI_API_KEY".to_string(),
+                "backend-openai-key".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::OpenaiResponses,
+            base_url: String::new(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "openai-responses".to_string(),
+            model: "gpt-5-codex".to_string(),
+            max_context_size: 200_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(provider.base_url, "https://backend.openai.test/v1");
+        assert_eq!(provider.api_key, "backend-openai-key");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_uses_backend_env_without_process_fallback() {
     let _lock = ENV_LOCK.lock().await;
     let _guards = [

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -371,6 +371,39 @@ async fn test_augment_provider_with_env_vars_kimi_prefers_provider_env_for_model
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_kimi_applies_context_size_to_fallback_model() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([(
+            "KIMI_MODEL_MAX_CONTEXT_SIZE".to_string(),
+            "262144".to_string(),
+        )]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Kimi,
+            base_url: "https://configured.test/v1".to_string(),
+            api_key: "configured-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "kimi".to_string(),
+            model: String::new(),
+            max_context_size: 0,
+            capabilities: None,
+        };
+
+        augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("backend env should fill fallback context size");
+
+        assert_eq!(model.max_context_size, 262_144);
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_anthropic_uses_backend_env() {
     let _lock = ENV_LOCK.lock().await;
 

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -780,6 +780,47 @@ async fn test_create_llm_scripted_echo_prefers_provider_env_without_mutating_pro
 }
 
 #[tokio::test]
+async fn test_create_llm_scripted_echo_uses_host_env_instead_of_backend_env() {
+    let _lock = ENV_LOCK.lock().await;
+    let temp_dir = TempDir::new().expect("temp dir");
+    let scripts_path = temp_dir.path().join("scripts.json");
+    std::fs::write(&scripts_path, r#"["text: from host env"]"#).expect("write scripts");
+    let host_path = scripts_path.to_string_lossy().to_string();
+    let _guard = EnvGuard::set("KIMI_SCRIPTED_ECHO_SCRIPTS", &host_path);
+
+    with_current_kaos_scope(async {
+        let _backend = BackendEnvKaosGuard::new(HashMap::from([(
+            "KIMI_SCRIPTED_ECHO_SCRIPTS".to_string(),
+            "/remote/does-not-exist.json".to_string(),
+        )]));
+
+        let llm = create_llm(
+            &LLMProvider {
+                provider_type: ProviderType::ScriptedEcho,
+                base_url: String::new(),
+                api_key: String::new(),
+                env: None,
+                custom_headers: None,
+            },
+            &LLMModel {
+                provider: "_scripted_echo".to_string(),
+                model: "scripted_echo".to_string(),
+                max_context_size: 10_000,
+                capabilities: None,
+            },
+            None,
+            None,
+        )
+        .await
+        .expect("create llm")
+        .expect("llm");
+
+        assert_eq!(llm.chat_provider.name(), "scripted_echo");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_create_llm_vertexai_uses_provider_scoped_api_key_env_without_mutating_process_env() {
     let _lock = ENV_LOCK.lock().await;
     let _guard = EnvGuard::set("VERTEXAI_API_KEY", "process-old-key");

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -188,15 +188,15 @@ async fn test_augment_provider_with_env_vars_kimi() {
 
     let mut provider = LLMProvider {
         provider_type: ProviderType::Kimi,
-        base_url: "https://original.test/v1".to_string(),
-        api_key: "orig-key".to_string(),
+        base_url: String::new(),
+        api_key: String::new(),
         env: None,
         custom_headers: None,
     };
     let mut model = LLMModel {
         provider: "kimi".to_string(),
-        model: "kimi-base".to_string(),
-        max_context_size: 4096,
+        model: String::new(),
+        max_context_size: 0,
         capabilities: None,
     };
 
@@ -229,6 +229,46 @@ async fn test_augment_provider_with_env_vars_kimi() {
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_preserves_explicit_kimi_config() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guards = [
+        EnvGuard::set("KIMI_BASE_URL", "https://env.test/v1"),
+        EnvGuard::set("KIMI_API_KEY", "env-key"),
+        EnvGuard::set("KIMI_MODEL_NAME", "kimi-env-model"),
+        EnvGuard::set("KIMI_MODEL_MAX_CONTEXT_SIZE", "8192"),
+        EnvGuard::set("KIMI_MODEL_CAPABILITIES", "Image_In,THINKING"),
+    ];
+
+    let mut provider = LLMProvider {
+        provider_type: ProviderType::Kimi,
+        base_url: "https://configured.test/v1".to_string(),
+        api_key: "configured-key".to_string(),
+        env: None,
+        custom_headers: None,
+    };
+    let mut model = LLMModel {
+        provider: "kimi".to_string(),
+        model: "kimi-configured".to_string(),
+        max_context_size: 4096,
+        capabilities: Some(HashSet::from([ModelCapability::VideoIn])),
+    };
+
+    let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+        .await
+        .expect("env overrides");
+
+    assert!(applied.is_empty());
+    assert_eq!(provider.base_url, "https://configured.test/v1");
+    assert_eq!(provider.api_key, "configured-key");
+    assert_eq!(model.model, "kimi-configured");
+    assert_eq!(model.max_context_size, 4096);
+    assert_eq!(
+        model.capabilities,
+        Some(HashSet::from([ModelCapability::VideoIn]))
+    );
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_invalid_max_context_size() {
     let _lock = ENV_LOCK.lock().await;
     let _guard = EnvGuard::set("KIMI_MODEL_MAX_CONTEXT_SIZE", "not-a-number");
@@ -243,7 +283,7 @@ async fn test_augment_provider_with_env_vars_invalid_max_context_size() {
     let mut model = LLMModel {
         provider: "kimi".to_string(),
         model: "kimi-base".to_string(),
-        max_context_size: 4096,
+        max_context_size: 0,
         capabilities: None,
     };
 
@@ -298,6 +338,47 @@ async fn test_augment_provider_with_env_vars_anthropic_uses_backend_env() {
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_preserves_explicit_anthropic_config() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "ANTHROPIC_BASE_URL".to_string(),
+                "https://backend.anthropic.test".to_string(),
+            ),
+            (
+                "ANTHROPIC_API_KEY".to_string(),
+                "backend-anthropic-key".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Anthropic,
+            base_url: "https://configured.anthropic.test".to_string(),
+            api_key: "configured-anthropic-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4".to_string(),
+            max_context_size: 200_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(provider.base_url, "https://configured.anthropic.test");
+        assert_eq!(provider.api_key, "configured-anthropic-key");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_google_genai_uses_gemini_env_family() {
     let _lock = ENV_LOCK.lock().await;
 
@@ -342,6 +423,50 @@ async fn test_augment_provider_with_env_vars_google_genai_uses_gemini_env_family
 }
 
 #[tokio::test]
+async fn test_augment_provider_with_env_vars_preserves_explicit_google_genai_config() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "GEMINI_BASE_URL".to_string(),
+                "https://backend.gemini.test/v1beta/openai".to_string(),
+            ),
+            (
+                "GEMINI_API_KEY".to_string(),
+                "backend-gemini-key".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::GoogleGenai,
+            base_url: "https://configured.gemini.test/v1beta/openai".to_string(),
+            api_key: "configured-gemini-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "google".to_string(),
+            model: "gemini-2.5-flash".to_string(),
+            max_context_size: 1_000_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(
+            provider.base_url,
+            "https://configured.gemini.test/v1beta/openai"
+        );
+        assert_eq!(provider.api_key, "configured-gemini-key");
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_augment_provider_with_env_vars_openai_responses_uses_openai_env_family() {
     let _lock = ENV_LOCK.lock().await;
 
@@ -378,6 +503,47 @@ async fn test_augment_provider_with_env_vars_openai_responses_uses_openai_env_fa
         assert!(applied.is_empty());
         assert_eq!(provider.base_url, "https://backend.openai.test/v1");
         assert_eq!(provider.api_key, "backend-openai-key");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_preserves_explicit_vertexai_config() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "VERTEXAI_BASE_URL".to_string(),
+                "https://backend.vertex.test/v1".to_string(),
+            ),
+            (
+                "VERTEXAI_API_KEY".to_string(),
+                "backend-vertex-key".to_string(),
+            ),
+        ]));
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Vertexai,
+            base_url: "https://configured.vertex.test/v1".to_string(),
+            api_key: "configured-vertex-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "vertex".to_string(),
+            model: "gemini-3-pro-preview".to_string(),
+            max_context_size: 1_000_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(provider.base_url, "https://configured.vertex.test/v1");
+        assert_eq!(provider.api_key, "configured-vertex-key");
     })
     .await;
 }

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use kaos::{
     CurrentKaosToken, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos, StrOrKaosPath,
     reset_current_kaos, set_current_kaos, with_current_kaos_scope,
@@ -56,13 +57,15 @@ impl Drop for EnvGuard {
 struct BackendEnvKaos {
     inner: LocalKaos,
     env: HashMap<String, String>,
+    failing_keys: HashSet<String>,
 }
 
 impl BackendEnvKaos {
-    fn new(env: HashMap<String, String>) -> Self {
+    fn with_failing_keys(env: HashMap<String, String>, failing_keys: HashSet<String>) -> Self {
         Self {
             inner: LocalKaos::new(),
             env,
+            failing_keys,
         }
     }
 }
@@ -147,6 +150,9 @@ impl Kaos for BackendEnvKaos {
     }
 
     async fn env_var(&self, key: &str) -> anyhow::Result<Option<String>> {
+        if self.failing_keys.contains(key) {
+            return Err(anyhow!("backend env lookup failed for `{key}`"));
+        }
         Ok(self.env.get(key).cloned())
     }
 
@@ -161,7 +167,11 @@ struct BackendEnvKaosGuard {
 
 impl BackendEnvKaosGuard {
     fn new(env: HashMap<String, String>) -> Self {
-        let kaos = Arc::new(BackendEnvKaos::new(env));
+        Self::with_failing_keys(env, HashSet::new())
+    }
+
+    fn with_failing_keys(env: HashMap<String, String>, failing_keys: HashSet<String>) -> Self {
+        let kaos = Arc::new(BackendEnvKaos::with_failing_keys(env, failing_keys));
         let token = set_current_kaos(kaos);
         Self { token: Some(token) }
     }
@@ -370,6 +380,44 @@ async fn test_augment_provider_with_env_vars_preserves_explicit_anthropic_config
         let applied = augment_provider_with_env_vars(&mut provider, &mut model)
             .await
             .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(provider.base_url, "https://configured.anthropic.test");
+        assert_eq!(provider.api_key, "configured-anthropic-key");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_skips_backend_probe_for_explicit_credentials() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::with_failing_keys(
+            HashMap::new(),
+            HashSet::from([
+                "ANTHROPIC_BASE_URL".to_string(),
+                "ANTHROPIC_API_KEY".to_string(),
+            ]),
+        );
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Anthropic,
+            base_url: "https://configured.anthropic.test".to_string(),
+            api_key: "configured-anthropic-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-4".to_string(),
+            max_context_size: 200_000,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("explicit config should not probe failing backend env");
 
         assert!(applied.is_empty());
         assert_eq!(provider.base_url, "https://configured.anthropic.test");
@@ -715,6 +763,79 @@ async fn test_create_llm_invalid_temperature_env() {
         err.to_string()
             .contains("could not convert string to float")
     );
+}
+
+#[tokio::test]
+async fn test_create_llm_kimi_ignores_optional_backend_env_lookup_failures() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::with_failing_keys(
+            HashMap::new(),
+            HashSet::from([
+                "KIMI_MODEL_TEMPERATURE".to_string(),
+                "KIMI_MODEL_TOP_P".to_string(),
+                "KIMI_MODEL_MAX_TOKENS".to_string(),
+            ]),
+        );
+
+        let provider = LLMProvider {
+            provider_type: ProviderType::Kimi,
+            base_url: "https://kimi.test/v1".to_string(),
+            api_key: "kimi-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let model = LLMModel {
+            provider: "kimi".to_string(),
+            model: "kimi-k2-0905-preview".to_string(),
+            max_context_size: 128_000,
+            capabilities: None,
+        };
+
+        let llm = create_llm(&provider, &model, None, None)
+            .await
+            .expect("optional backend env lookup failure should be ignored")
+            .expect("llm");
+
+        assert!(llm.chat_provider.as_any().is::<Kimi>());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_create_llm_vertexai_ignores_optional_backend_env_lookup_failures() {
+    let _lock = ENV_LOCK.lock().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::with_failing_keys(
+            HashMap::new(),
+            HashSet::from(["VERTEXAI_MODEL_TEMPERATURE".to_string()]),
+        );
+
+        let provider = LLMProvider {
+            provider_type: ProviderType::Vertexai,
+            base_url: "https://vertex.test/v1".to_string(),
+            api_key: "vertex-key".to_string(),
+            env: None,
+            custom_headers: None,
+        };
+        let model = LLMModel {
+            provider: "vertex".to_string(),
+            model: "gemini-3-pro-preview".to_string(),
+            max_context_size: 1_000_000,
+            capabilities: None,
+        };
+
+        let llm = create_llm(&provider, &model, None, None)
+            .await
+            .expect("optional backend env lookup failure should be ignored")
+            .expect("llm");
+
+        assert!(llm.chat_provider.as_any().is::<OpenAILegacy>());
+        assert_eq!(llm.chat_provider.name(), "vertexai");
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -1,5 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
+use kaos::{
+    CurrentKaosToken, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos, StrOrKaosPath,
+    reset_current_kaos, set_current_kaos, with_current_kaos_scope,
+};
 use serde_json::json;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
@@ -48,9 +53,131 @@ impl Drop for EnvGuard {
     }
 }
 
-#[test]
-fn test_augment_provider_with_env_vars_kimi() {
-    let _lock = ENV_LOCK.blocking_lock();
+struct BackendEnvKaos {
+    inner: LocalKaos,
+    env: HashMap<String, String>,
+}
+
+impl BackendEnvKaos {
+    fn new(env: HashMap<String, String>) -> Self {
+        Self {
+            inner: LocalKaos::new(),
+            env,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Kaos for BackendEnvKaos {
+    fn name(&self) -> &str {
+        "test-backend"
+    }
+
+    fn platform(&self) -> kaos::KaosPlatform {
+        self.inner.platform()
+    }
+
+    fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath {
+        self.inner.normpath(path)
+    }
+
+    fn home(&self) -> KaosPath {
+        self.inner.home()
+    }
+
+    fn cwd(&self) -> KaosPath {
+        self.inner.cwd()
+    }
+
+    async fn chdir(&self, path: &KaosPath) -> anyhow::Result<()> {
+        self.inner.chdir(path).await
+    }
+
+    async fn stat(
+        &self,
+        path: &KaosPath,
+        follow_symlinks: bool,
+    ) -> anyhow::Result<kaos::StatResult> {
+        self.inner.stat(path, follow_symlinks).await
+    }
+
+    async fn iterdir(&self, path: &KaosPath) -> anyhow::Result<Vec<KaosPath>> {
+        self.inner.iterdir(path).await
+    }
+
+    async fn glob(
+        &self,
+        path: &KaosPath,
+        pattern: &str,
+        case_sensitive: bool,
+    ) -> anyhow::Result<Vec<KaosPath>> {
+        self.inner.glob(path, pattern, case_sensitive).await
+    }
+
+    async fn read_bytes(&self, path: &KaosPath, limit: Option<usize>) -> anyhow::Result<Vec<u8>> {
+        self.inner.read_bytes(path, limit).await
+    }
+
+    async fn read_text(&self, path: &KaosPath) -> anyhow::Result<String> {
+        self.inner.read_text(path).await
+    }
+
+    async fn read_lines(&self, path: &KaosPath) -> anyhow::Result<Vec<String>> {
+        self.inner.read_lines(path).await
+    }
+
+    async fn read_lines_stream(&self, path: &KaosPath) -> anyhow::Result<LineStream> {
+        self.inner.read_lines_stream(path).await
+    }
+
+    async fn write_bytes(&self, path: &KaosPath, data: &[u8]) -> anyhow::Result<usize> {
+        self.inner.write_bytes(path, data).await
+    }
+
+    async fn write_text(&self, path: &KaosPath, data: &str, append: bool) -> anyhow::Result<usize> {
+        self.inner.write_text(path, data, append).await
+    }
+
+    async fn chmod(&self, path: &KaosPath, mode: u32) -> anyhow::Result<()> {
+        self.inner.chmod(path, mode).await
+    }
+
+    async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> anyhow::Result<()> {
+        self.inner.mkdir(path, parents, exist_ok).await
+    }
+
+    async fn env_var(&self, key: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.env.get(key).cloned())
+    }
+
+    async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn KaosProcess>> {
+        self.inner.exec(args).await
+    }
+}
+
+struct BackendEnvKaosGuard {
+    token: Option<CurrentKaosToken>,
+}
+
+impl BackendEnvKaosGuard {
+    fn new(env: HashMap<String, String>) -> Self {
+        let kaos = Arc::new(BackendEnvKaos::new(env));
+        let token = set_current_kaos(kaos);
+        Self { token: Some(token) }
+    }
+}
+
+impl Drop for BackendEnvKaosGuard {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            reset_current_kaos(token);
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_kimi() {
+    let _lock = ENV_LOCK.lock().await;
     let _guards = [
         EnvGuard::set("KIMI_BASE_URL", "https://env.test/v1"),
         EnvGuard::set("KIMI_API_KEY", "env-key"),
@@ -73,7 +200,9 @@ fn test_augment_provider_with_env_vars_kimi() {
         capabilities: None,
     };
 
-    augment_provider_with_env_vars(&mut provider, &mut model).expect("env overrides");
+    augment_provider_with_env_vars(&mut provider, &mut model)
+        .await
+        .expect("env overrides");
 
     assert_eq!(
         provider,
@@ -99,9 +228,9 @@ fn test_augment_provider_with_env_vars_kimi() {
     );
 }
 
-#[test]
-fn test_augment_provider_with_env_vars_invalid_max_context_size() {
-    let _lock = ENV_LOCK.blocking_lock();
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_invalid_max_context_size() {
+    let _lock = ENV_LOCK.lock().await;
     let _guard = EnvGuard::set("KIMI_MODEL_MAX_CONTEXT_SIZE", "not-a-number");
 
     let mut provider = LLMProvider {
@@ -119,11 +248,108 @@ fn test_augment_provider_with_env_vars_invalid_max_context_size() {
     };
 
     let err = augment_provider_with_env_vars(&mut provider, &mut model)
+        .await
         .expect_err("invalid max context size");
     assert!(
         err.to_string()
             .contains("invalid literal for int() with base 10")
     );
+}
+
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_uses_backend_env_without_process_fallback() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guards = [
+        EnvGuard::set("KIMI_BASE_URL", "https://host.test/v1"),
+        EnvGuard::set("KIMI_API_KEY", "host-key"),
+    ];
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::new());
+
+        let mut provider = LLMProvider {
+            provider_type: ProviderType::Kimi,
+            base_url: String::new(),
+            api_key: String::new(),
+            env: None,
+            custom_headers: None,
+        };
+        let mut model = LLMModel {
+            provider: "kimi".to_string(),
+            model: "kimi-base".to_string(),
+            max_context_size: 4096,
+            capabilities: None,
+        };
+
+        let applied = augment_provider_with_env_vars(&mut provider, &mut model)
+            .await
+            .expect("env overrides");
+
+        assert!(applied.is_empty());
+        assert_eq!(provider.base_url, "");
+        assert_eq!(provider.api_key, "");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_augment_provider_with_env_vars_prefers_provider_env_over_backend_env() {
+    let _lock = ENV_LOCK.lock().await;
+    let mock_server = MockServer::start().await;
+
+    with_current_kaos_scope(async {
+        let _guard = BackendEnvKaosGuard::new(HashMap::from([
+            (
+                "OPENAI_BASE_URL".to_string(),
+                "https://backend.invalid/v1".to_string(),
+            ),
+            ("OPENAI_API_KEY".to_string(), "backend-key".to_string()),
+        ]));
+
+        let base_url = format!("{}/v1", mock_server.uri());
+        let api_key = "provider-key".to_string();
+
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header("authorization", "Bearer provider-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let llm = create_llm(
+            &LLMProvider {
+                provider_type: ProviderType::Vertexai,
+                base_url: base_url.clone(),
+                api_key: String::new(),
+                env: Some(HashMap::from([(
+                    "OPENAI_API_KEY".to_string(),
+                    api_key.clone(),
+                )])),
+                custom_headers: None,
+            },
+            &LLMModel {
+                provider: "vertex".to_string(),
+                model: "gemini-3-pro-preview".to_string(),
+                max_context_size: 1_000_000,
+                capabilities: None,
+            },
+            None,
+            None,
+        )
+        .await
+        .expect("create llm")
+        .expect("llm");
+
+        let tools: Vec<kosong::tooling::Tool> = vec![];
+        let history: Vec<kosong::message::Message> = vec![];
+        let _stream = llm
+            .chat_provider
+            .generate("", &tools, &history)
+            .await
+            .expect("generate request should use provider env values");
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/kimi-agent/tests/environment.rs
+++ b/kimi-agent/tests/environment.rs
@@ -8,6 +8,9 @@ use kaos::{
 use kimi_agent::utils::Environment;
 use tempfile::TempDir;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 struct EnvOnlyKaos {
     inner: LocalKaos,
     env: HashMap<String, String>,
@@ -186,6 +189,9 @@ async fn test_environment_detection_accepts_backend_zsh_env() {
     let temp = TempDir::new().expect("temp dir");
     let zsh_path = temp.path().join("zsh");
     std::fs::write(&zsh_path, "#!/bin/zsh\n").expect("write fake zsh");
+    #[cfg(unix)]
+    std::fs::set_permissions(&zsh_path, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fake zsh");
 
     with_current_kaos_scope(async {
         let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
@@ -202,6 +208,34 @@ async fn test_environment_detection_accepts_backend_zsh_env() {
         let env = Environment::detect().await;
         assert_eq!(env.shell_name, "zsh");
         assert_eq!(env.shell_path.to_string_lossy(), zsh_path.to_string_lossy());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_environment_detection_ignores_non_executable_backend_shell_env() {
+    let temp = TempDir::new().expect("temp dir");
+    let zsh_path = temp.path().join("zsh");
+    std::fs::write(&zsh_path, "#!/bin/zsh\n").expect("write fake zsh");
+    #[cfg(unix)]
+    std::fs::set_permissions(&zsh_path, std::fs::Permissions::from_mode(0o644))
+        .expect("chmod fake zsh");
+
+    with_current_kaos_scope(async {
+        let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
+            "ssh",
+            HashMap::from([("SHELL".to_string(), zsh_path.to_string_lossy().to_string())]),
+            KaosPlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                abi: None,
+                libc: Some("gnu".to_string()),
+            },
+        ));
+
+        let env = Environment::detect().await;
+        assert_ne!(env.shell_path.to_string_lossy(), zsh_path.to_string_lossy());
+        assert!(env.shell_name == "bash" || env.shell_name == "zsh" || env.shell_name == "sh");
     })
     .await;
 }

--- a/kimi-agent/tests/environment.rs
+++ b/kimi-agent/tests/environment.rs
@@ -1,4 +1,136 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use kaos::{
+    CurrentKaosToken, Kaos, KaosPath, KaosPlatform, KaosProcess, LineStream, LocalKaos,
+    StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
+};
 use kimi_agent::utils::Environment;
+
+struct EnvOnlyKaos {
+    inner: LocalKaos,
+    env: HashMap<String, String>,
+    name: &'static str,
+    platform: KaosPlatform,
+}
+
+impl EnvOnlyKaos {
+    fn new(name: &'static str, env: HashMap<String, String>, platform: KaosPlatform) -> Self {
+        Self {
+            inner: LocalKaos::new(),
+            env,
+            name,
+            platform,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Kaos for EnvOnlyKaos {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn platform(&self) -> KaosPlatform {
+        self.platform.clone()
+    }
+
+    fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath {
+        self.inner.normpath(path)
+    }
+
+    fn home(&self) -> KaosPath {
+        self.inner.home()
+    }
+
+    fn cwd(&self) -> KaosPath {
+        self.inner.cwd()
+    }
+
+    async fn chdir(&self, path: &KaosPath) -> anyhow::Result<()> {
+        self.inner.chdir(path).await
+    }
+
+    async fn stat(
+        &self,
+        path: &KaosPath,
+        follow_symlinks: bool,
+    ) -> anyhow::Result<kaos::StatResult> {
+        self.inner.stat(path, follow_symlinks).await
+    }
+
+    async fn iterdir(&self, path: &KaosPath) -> anyhow::Result<Vec<KaosPath>> {
+        self.inner.iterdir(path).await
+    }
+
+    async fn glob(
+        &self,
+        path: &KaosPath,
+        pattern: &str,
+        case_sensitive: bool,
+    ) -> anyhow::Result<Vec<KaosPath>> {
+        self.inner.glob(path, pattern, case_sensitive).await
+    }
+
+    async fn read_bytes(&self, path: &KaosPath, limit: Option<usize>) -> anyhow::Result<Vec<u8>> {
+        self.inner.read_bytes(path, limit).await
+    }
+
+    async fn read_text(&self, path: &KaosPath) -> anyhow::Result<String> {
+        self.inner.read_text(path).await
+    }
+
+    async fn read_lines(&self, path: &KaosPath) -> anyhow::Result<Vec<String>> {
+        self.inner.read_lines(path).await
+    }
+
+    async fn read_lines_stream(&self, path: &KaosPath) -> anyhow::Result<LineStream> {
+        self.inner.read_lines_stream(path).await
+    }
+
+    async fn write_bytes(&self, path: &KaosPath, data: &[u8]) -> anyhow::Result<usize> {
+        self.inner.write_bytes(path, data).await
+    }
+
+    async fn write_text(&self, path: &KaosPath, data: &str, append: bool) -> anyhow::Result<usize> {
+        self.inner.write_text(path, data, append).await
+    }
+
+    async fn chmod(&self, path: &KaosPath, mode: u32) -> anyhow::Result<()> {
+        self.inner.chmod(path, mode).await
+    }
+
+    async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> anyhow::Result<()> {
+        self.inner.mkdir(path, parents, exist_ok).await
+    }
+
+    async fn env_var(&self, key: &str) -> anyhow::Result<Option<String>> {
+        Ok(self.env.get(key).cloned())
+    }
+
+    async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn KaosProcess>> {
+        self.inner.exec(args).await
+    }
+}
+
+struct EnvOnlyKaosGuard {
+    token: Option<CurrentKaosToken>,
+}
+
+impl EnvOnlyKaosGuard {
+    fn new(kaos: EnvOnlyKaos) -> Self {
+        let token = set_current_kaos(Arc::new(kaos));
+        Self { token: Some(token) }
+    }
+}
+
+impl Drop for EnvOnlyKaosGuard {
+    fn drop(&mut self) {
+        if let Some(token) = self.token.take() {
+            reset_current_kaos(token);
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_environment_detection() {
@@ -21,4 +153,47 @@ async fn test_environment_detection() {
             assert!(shell_path.ends_with("sh"));
         }
     }
+}
+
+#[tokio::test]
+async fn test_environment_detection_prefers_backend_shell_env_for_non_local_backend() {
+    with_current_kaos_scope(async {
+        let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
+            "ssh",
+            HashMap::from([("SHELL".to_string(), "/bin/bash".to_string())]),
+            KaosPlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                abi: None,
+                libc: Some("gnu".to_string()),
+            },
+        ));
+
+        let env = Environment::detect().await;
+        assert_eq!(env.os_kind, "Linux");
+        assert_eq!(env.os_version, "");
+        assert_eq!(env.shell_name, "bash");
+        assert_eq!(env.shell_path.to_string_lossy(), "/bin/bash");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_environment_detection_ignores_unsupported_backend_shell_env() {
+    with_current_kaos_scope(async {
+        let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
+            "ssh",
+            HashMap::from([("SHELL".to_string(), "/usr/bin/fish".to_string())]),
+            KaosPlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                abi: None,
+                libc: Some("gnu".to_string()),
+            },
+        ));
+
+        let env = Environment::detect().await;
+        assert!(env.shell_name == "bash" || env.shell_name == "sh");
+    })
+    .await;
 }

--- a/kimi-agent/tests/environment.rs
+++ b/kimi-agent/tests/environment.rs
@@ -6,6 +6,7 @@ use kaos::{
     StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
 };
 use kimi_agent::utils::Environment;
+use tempfile::TempDir;
 
 struct EnvOnlyKaos {
     inner: LocalKaos,
@@ -144,11 +145,13 @@ async fn test_environment_detection() {
         assert_eq!(env.shell_name, "Windows PowerShell");
         assert_eq!(env.shell_path.to_string_lossy(), "powershell.exe");
     } else {
-        assert!(env.shell_name == "bash" || env.shell_name == "sh");
+        assert!(env.shell_name == "bash" || env.shell_name == "zsh" || env.shell_name == "sh");
         let shell_path = env.shell_path.to_string_lossy();
         assert!(!shell_path.is_empty());
         if env.shell_name == "bash" {
             assert!(shell_path.ends_with("bash"));
+        } else if env.shell_name == "zsh" {
+            assert!(shell_path.ends_with("zsh"));
         } else {
             assert!(shell_path.ends_with("sh"));
         }
@@ -179,6 +182,64 @@ async fn test_environment_detection_prefers_backend_shell_env_for_non_local_back
 }
 
 #[tokio::test]
+async fn test_environment_detection_accepts_backend_zsh_env() {
+    let temp = TempDir::new().expect("temp dir");
+    let zsh_path = temp.path().join("zsh");
+    std::fs::write(&zsh_path, "#!/bin/zsh\n").expect("write fake zsh");
+
+    with_current_kaos_scope(async {
+        let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
+            "ssh",
+            HashMap::from([("SHELL".to_string(), zsh_path.to_string_lossy().to_string())]),
+            KaosPlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                abi: None,
+                libc: Some("gnu".to_string()),
+            },
+        ));
+
+        let env = Environment::detect().await;
+        assert_eq!(env.shell_name, "zsh");
+        assert_eq!(env.shell_path.to_string_lossy(), zsh_path.to_string_lossy());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_environment_detection_ignores_backend_sh_env_and_keeps_preferred_fallbacks() {
+    with_current_kaos_scope(async {
+        let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
+            "ssh",
+            HashMap::from([("SHELL".to_string(), "/bin/sh".to_string())]),
+            KaosPlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                abi: None,
+                libc: Some("gnu".to_string()),
+            },
+        ));
+
+        let env = Environment::detect().await;
+        let expected = if std::path::Path::new("/bin/bash").is_file()
+            || std::path::Path::new("/usr/bin/bash").is_file()
+            || std::path::Path::new("/usr/local/bin/bash").is_file()
+        {
+            "bash"
+        } else if std::path::Path::new("/bin/zsh").is_file()
+            || std::path::Path::new("/usr/bin/zsh").is_file()
+            || std::path::Path::new("/usr/local/bin/zsh").is_file()
+        {
+            "zsh"
+        } else {
+            "sh"
+        };
+        assert_eq!(env.shell_name, expected);
+    })
+    .await;
+}
+
+#[tokio::test]
 async fn test_environment_detection_ignores_unsupported_backend_shell_env() {
     with_current_kaos_scope(async {
         let _guard = EnvOnlyKaosGuard::new(EnvOnlyKaos::new(
@@ -193,7 +254,7 @@ async fn test_environment_detection_ignores_unsupported_backend_shell_env() {
         ));
 
         let env = Environment::detect().await;
-        assert!(env.shell_name == "bash" || env.shell_name == "sh");
+        assert!(env.shell_name == "bash" || env.shell_name == "zsh" || env.shell_name == "sh");
     })
     .await;
 }

--- a/kimi-agent/tests/skill.rs
+++ b/kimi-agent/tests/skill.rs
@@ -105,6 +105,10 @@ impl Kaos for FixedHomeKaos {
         self.inner.mkdir(path, parents, exist_ok).await
     }
 
+    async fn env_var(&self, key: &str) -> anyhow::Result<Option<String>> {
+        self.inner.env_var(key).await
+    }
+
     async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn KaosProcess>> {
         self.inner.exec(args).await
     }

--- a/kimi-agent/tests/tool_schemas.rs
+++ b/kimi-agent/tests/tool_schemas.rs
@@ -183,7 +183,7 @@ fn test_shell_params_schema() {
         serde_json::json!({
             "properties": {
                 "command": {
-                    "description": "The bash command to execute.",
+                    "description": "The shell command to execute.",
                     "type": "string",
                 },
                 "timeout": {

--- a/kimi-agent/tests/tool_test_utils.rs
+++ b/kimi-agent/tests/tool_test_utils.rs
@@ -244,6 +244,10 @@ impl Kaos for TestKaos {
         self.inner.mkdir(path, parents, exist_ok).await
     }
 
+    async fn env_var(&self, key: &str) -> anyhow::Result<Option<String>> {
+        self.inner.env_var(key).await
+    }
+
     async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn kaos::KaosProcess>> {
         self.inner.exec(args).await
     }

--- a/kosong/src/chat_provider/anthropic/provider.rs
+++ b/kosong/src/chat_provider/anthropic/provider.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::env;
 
 use async_trait::async_trait;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue, USER_AGENT};
@@ -41,11 +40,9 @@ impl Anthropic {
     ) -> Result<Self, ChatProviderError> {
         let api_key = api_key
             .filter(|value| !value.is_empty())
-            .or_else(|| env::var("ANTHROPIC_API_KEY").ok())
             .unwrap_or_default();
         let mut base_url = base_url
             .filter(|value| !value.is_empty())
-            .or_else(|| env::var("ANTHROPIC_BASE_URL").ok())
             .unwrap_or_else(|| "https://api.anthropic.com".to_string());
         if !base_url.ends_with('/') {
             base_url.push('/');

--- a/kosong/src/chat_provider/kimi.rs
+++ b/kosong/src/chat_provider/kimi.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
-use std::env;
 use std::pin::Pin;
 
 use async_trait::async_trait;
@@ -41,17 +40,13 @@ impl Kimi {
         base_url: Option<String>,
         default_headers: Option<HeaderMap>,
     ) -> Result<Self, ChatProviderError> {
-        let api_key = api_key
-            .or_else(|| env::var("KIMI_API_KEY").ok())
-            .ok_or_else(|| {
-                ChatProviderError::new(
-                    ChatProviderErrorKind::Other,
-                    "The api_key client option or the KIMI_API_KEY environment variable is not set",
-                )
-            })?;
-        let mut base_url = base_url
-            .or_else(|| env::var("KIMI_BASE_URL").ok())
-            .unwrap_or_else(|| "https://api.moonshot.ai/v1".to_string());
+        let api_key = api_key.ok_or_else(|| {
+            ChatProviderError::new(
+                ChatProviderErrorKind::Other,
+                "The api_key client option is not set",
+            )
+        })?;
+        let mut base_url = base_url.unwrap_or_else(|| "https://api.moonshot.ai/v1".to_string());
         if !base_url.ends_with('/') {
             base_url.push('/');
         }

--- a/kosong/src/chat_provider/openai_legacy.rs
+++ b/kosong/src/chat_provider/openai_legacy.rs
@@ -1,6 +1,5 @@
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
-use std::env;
 use std::pin::Pin;
 
 use async_trait::async_trait;
@@ -43,13 +42,9 @@ impl OpenAILegacy {
         base_url: Option<String>,
         default_headers: Option<HeaderMap>,
     ) -> Result<Self, ChatProviderError> {
-        let api_key = match api_key {
-            Some(value) => value,
-            None => env::var("OPENAI_API_KEY").unwrap_or_default(),
-        };
+        let api_key = api_key.unwrap_or_default();
         let mut base_url = base_url
             .filter(|value| !value.is_empty())
-            .or_else(|| env::var("OPENAI_BASE_URL").ok())
             .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
         if !base_url.ends_with('/') {
             base_url.push('/');

--- a/kosong/src/chat_provider/openai_responses/provider.rs
+++ b/kosong/src/chat_provider/openai_responses/provider.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::env;
 
 use async_trait::async_trait;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue, USER_AGENT};
@@ -35,11 +34,9 @@ impl OpenAIResponses {
     ) -> Result<Self, ChatProviderError> {
         let api_key = api_key
             .filter(|value| !value.is_empty())
-            .or_else(|| env::var("OPENAI_API_KEY").ok())
             .unwrap_or_default();
         let mut base_url = base_url
             .filter(|value| !value.is_empty())
-            .or_else(|| env::var("OPENAI_BASE_URL").ok())
             .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
         if !base_url.ends_with('/') {
             base_url.push('/');


### PR DESCRIPTION
## Summary
This PR adds backend-scoped environment reads to the Rust implementation by teaching `kaos` how to resolve environment variables from the active backend, then routing the relevant Rust runtime lookups through that abstraction.

## What This PR Does
- add a read-only `env_var` API to Rust `kaos`
- implement backend-aware env lookup for `LocalKaos` and `SshKaos`
- migrate Rust-side LLM and runtime env reads that should follow the active backend
- make `kimi-agent` the single env-resolution boundary and remove implicit env fallback from `kosong` provider constructors
- add regression tests for backend-scoped env resolution, host-local exceptions, and SSH env lookup behavior

## Env Resolution Contract
- for the runtime paths updated in this PR, ambient env is scoped to the active backend, not the launcher process
- precedence is `explicit config > provider.env > backend env`
- logical provider env families are kept separate from the transport implementation:
  - `KIMI_*` for Kimi
  - `OPENAI_*` for OpenAI legacy and OpenAI responses
  - `ANTHROPIC_*` for Anthropic
  - `GEMINI_*` for Google GenAI and Gemini
  - `VERTEXAI_*` for Vertex AI

## Host-Local Exceptions
These remain local by design because they are resolved or consumed on the agent host:
- `KIMI_SHARE_DIR`
- `_scripted_echo` script path and trace env
- local bundled dependency discovery beside the binary
- SSH bootstrap defaults needed before a remote session exists

## Non-Goals
- this PR is intentionally read-only for env access
- `kaos::exec(..., env=...)` is not part of this change and is tracked separately in #11

## Why This Shape
This keeps the boundaries clean:
- `kaos` owns backend-specific environment reads
- `kimi-agent` owns env resolution policy
- `kosong` stays env-agnostic during provider construction

## Testing
- `cargo test -p kaos`
- `cargo test -p kosong`
- `cargo test -p kimi-agent`
- `cargo clippy --workspace --all-targets`

Closes #8
