### PR TITLE
feat(kaos): support exec env overrides

### DIFF
--- a/kaos/src/lib.rs
+++ b/kaos/src/lib.rs
@@ -15,6 +15,7 @@ pub use local::LocalKaos;
 pub use path::{KaosPath, KaosPathStyle};
 pub use ssh::{SshHostKeyPolicy, SshKaos, SshKaosOptions};
 
+use std::collections::BTreeMap;
 use std::pin::Pin;
 
 use anyhow::Result;
@@ -58,6 +59,12 @@ pub struct ProcessOutputOverflow {
     pub stdout_dropped_bytes: u64,
     pub stderr_dropped_chunks: u64,
     pub stderr_dropped_bytes: u64,
+}
+
+/// Process execution options for Kaos backends.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExecOptions {
+    pub env_overrides: BTreeMap<String, String>,
 }
 
 impl ProcessOutputOverflow {
@@ -133,7 +140,7 @@ pub trait Kaos: Send + Sync {
     async fn chmod(&self, path: &KaosPath, mode: u32) -> Result<()>;
     async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> Result<()>;
     async fn env_var(&self, key: &str) -> Result<Option<String>>;
-    async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>>;
+    async fn exec(&self, args: &[String], options: ExecOptions) -> Result<Box<dyn KaosProcess>>;
 }
 
 /// Stat result compatible with Python fields.
@@ -230,5 +237,12 @@ pub async fn env_var(key: &str) -> Result<Option<String>> {
 }
 
 pub async fn exec(args: &[String]) -> Result<Box<dyn KaosProcess>> {
-    get_current_kaos().exec(args).await
+    exec_with_options(args, ExecOptions::default()).await
+}
+
+pub async fn exec_with_options(
+    args: &[String],
+    options: ExecOptions,
+) -> Result<Box<dyn KaosProcess>> {
+    get_current_kaos().exec(args, options).await
 }

--- a/kaos/src/local.rs
+++ b/kaos/src/local.rs
@@ -6,8 +6,8 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWrite
 use tokio::process::Command;
 
 use crate::{
-    AsyncReadable, AsyncWritable, Kaos, KaosPath, KaosPlatform, KaosProcess, LineStream,
-    StatResult, StrOrKaosPath, line_stream::line_stream_from_async_read,
+    AsyncReadable, AsyncWritable, ExecOptions, Kaos, KaosPath, KaosPlatform, KaosProcess,
+    LineStream, StatResult, StrOrKaosPath, line_stream::line_stream_from_async_read,
 };
 
 #[cfg(unix)]
@@ -428,7 +428,7 @@ impl Kaos for LocalKaos {
         }
     }
 
-    async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>> {
+    async fn exec(&self, args: &[String], options: ExecOptions) -> Result<Box<dyn KaosProcess>> {
         if args.is_empty() {
             return Err(anyhow!("missing command"));
         }
@@ -436,6 +436,7 @@ impl Kaos for LocalKaos {
         if args.len() > 1 {
             command.args(&args[1..]);
         }
+        command.envs(options.env_overrides.iter());
         command.stdin(std::process::Stdio::piped());
         command.stdout(std::process::Stdio::piped());
         command.stderr(std::process::Stdio::piped());

--- a/kaos/src/ssh.rs
+++ b/kaos/src/ssh.rs
@@ -21,8 +21,8 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc, watch};
 use typed_path::Utf8TypedPathBuf;
 
 use crate::{
-    AsyncReadable, AsyncWritable, Kaos, KaosPath, KaosPathStyle, KaosPlatform, KaosProcess,
-    LineStream, ProcessOutputOverflow, StatResult, StrOrKaosPath,
+    AsyncReadable, AsyncWritable, ExecOptions, Kaos, KaosPath, KaosPathStyle, KaosPlatform,
+    KaosProcess, LineStream, ProcessOutputOverflow, StatResult, StrOrKaosPath,
     line_stream::line_stream_from_async_read,
 };
 
@@ -579,7 +579,7 @@ impl Kaos for SshKaos {
         Ok(value)
     }
 
-    async fn exec(&self, args: &[String]) -> Result<Box<dyn KaosProcess>> {
+    async fn exec(&self, args: &[String], options: ExecOptions) -> Result<Box<dyn KaosProcess>> {
         if args.is_empty() {
             bail!("missing command");
         }
@@ -595,7 +595,24 @@ impl Kaos for SshKaos {
         let handle = self.state.handle.lock().await;
         let channel = handle.channel_open_session().await?;
         let (mut read_half, write_half) = channel.split();
+        // Keep SSH env injection aligned with the Python AsyncSSH backend by using
+        // protocol-level "env" requests instead of shell-prefix tricks.
+        //
+        // Important caveat: common OpenSSH servers reject arbitrary environment
+        // variable names unless they are explicitly whitelisted via AcceptEnv in
+        // sshd_config. Callers should treat env_overrides on SSH as backend-
+        // dependent rather than universally portable.
+        for (key, value) in &options.env_overrides {
+            validate_env_var_key(key)?;
+            write_half.set_env(true, key, value).await?;
+            await_channel_request_reply(
+                &mut read_half,
+                &format!("set environment variable `{key}`"),
+            )
+            .await?;
+        }
         write_half.exec(true, command).await?;
+        await_channel_request_reply(&mut read_half, "execute remote command").await?;
         let write_half = Arc::new(AsyncMutex::new(Some(write_half)));
         let stdin_writer = ChannelStdin {
             write_half: Arc::clone(&write_half),
@@ -1125,6 +1142,7 @@ async fn exec_capture_raw(
 ) -> Result<(i32, String, String)> {
     let mut channel = handle.channel_open_session().await?;
     channel.exec(true, command).await?;
+    map_channel_request_reply("execute remote command", channel.wait().await)?;
 
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -1145,6 +1163,59 @@ async fn exec_capture_raw(
         String::from_utf8_lossy(&stdout).to_string(),
         String::from_utf8_lossy(&stderr).to_string(),
     ))
+}
+
+async fn await_channel_request_reply(
+    read_half: &mut russh::ChannelReadHalf,
+    request_label: &str,
+) -> Result<()> {
+    map_channel_request_reply(request_label, read_half.wait().await)
+}
+
+fn map_channel_request_reply(request_label: &str, message: Option<ChannelMsg>) -> Result<()> {
+    match message {
+        Some(ChannelMsg::Success) => Ok(()),
+        Some(ChannelMsg::Failure) => {
+            bail!("SSH server rejected request to {request_label}")
+        }
+        Some(ChannelMsg::OpenFailure(reason)) => {
+            bail!("SSH channel open failure while waiting to {request_label}: {reason:?}")
+        }
+        Some(ChannelMsg::Close) | Some(ChannelMsg::Eof) | None => {
+            bail!("SSH channel closed while waiting to {request_label}")
+        }
+        Some(other) => bail!(
+            "Unexpected SSH channel message while waiting to {request_label}: {}",
+            channel_message_name(&other)
+        ),
+    }
+}
+
+fn channel_message_name(message: &ChannelMsg) -> &'static str {
+    match message {
+        ChannelMsg::Open { .. } => "open",
+        ChannelMsg::Data { .. } => "data",
+        ChannelMsg::ExtendedData { .. } => "extended_data",
+        ChannelMsg::Eof => "eof",
+        ChannelMsg::Close => "close",
+        ChannelMsg::RequestPty { .. } => "request_pty",
+        ChannelMsg::RequestShell { .. } => "request_shell",
+        ChannelMsg::Exec { .. } => "exec",
+        ChannelMsg::Signal { .. } => "signal",
+        ChannelMsg::RequestSubsystem { .. } => "request_subsystem",
+        ChannelMsg::RequestX11 { .. } => "request_x11",
+        ChannelMsg::SetEnv { .. } => "set_env",
+        ChannelMsg::WindowChange { .. } => "window_change",
+        ChannelMsg::AgentForward { .. } => "agent_forward",
+        ChannelMsg::XonXoff { .. } => "xon_xoff",
+        ChannelMsg::ExitStatus { .. } => "exit_status",
+        ChannelMsg::ExitSignal { .. } => "exit_signal",
+        ChannelMsg::WindowAdjusted { .. } => "window_adjusted",
+        ChannelMsg::Success => "success",
+        ChannelMsg::Failure => "failure",
+        ChannelMsg::OpenFailure(_) => "open_failure",
+        _ => "other",
+    }
 }
 
 const SSH_ENV_VAR_UNSET_EXIT_CODE: i32 = 3;
@@ -1334,10 +1405,11 @@ fn build_storage_name(host: &str, port: u16, username: &str) -> String {
 mod tests {
     use super::{
         GlobTraversalPlan, SSH_ENV_VAR_UNSET_EXIT_CODE, build_storage_name,
-        map_env_var_lookup_result, normalize_glob_pattern, resolve_absolute_posix,
-        validate_env_var_key,
+        map_channel_request_reply, map_env_var_lookup_result, normalize_glob_pattern,
+        resolve_absolute_posix, validate_env_var_key,
     };
     use crate::{KaosPath, KaosPathStyle};
+    use russh::{ChannelMsg, ChannelOpenFailure};
 
     #[test]
     fn storage_name_is_deterministic() {
@@ -1441,5 +1513,53 @@ mod tests {
             map_env_var_lookup_result("PATH", 1, String::new(), "permission denied".to_string())
                 .expect_err("failure");
         assert!(err.to_string().contains("permission denied"));
+    }
+
+    #[test]
+    fn map_channel_request_reply_accepts_success() {
+        map_channel_request_reply("execute remote command", Some(ChannelMsg::Success))
+            .expect("success");
+    }
+
+    #[test]
+    fn map_channel_request_reply_rejects_failure() {
+        let err = map_channel_request_reply("execute remote command", Some(ChannelMsg::Failure))
+            .expect_err("failure");
+        assert!(
+            err.to_string()
+                .contains("SSH server rejected request to execute remote command")
+        );
+    }
+
+    #[test]
+    fn map_channel_request_reply_rejects_close() {
+        let err = map_channel_request_reply("execute remote command", Some(ChannelMsg::Close))
+            .expect_err("close");
+        assert!(
+            err.to_string()
+                .contains("SSH channel closed while waiting to execute remote command")
+        );
+    }
+
+    #[test]
+    fn map_channel_request_reply_rejects_open_failure() {
+        let err = map_channel_request_reply(
+            "execute remote command",
+            Some(ChannelMsg::OpenFailure(
+                ChannelOpenFailure::AdministrativelyProhibited,
+            )),
+        )
+        .expect_err("open failure");
+        assert!(err.to_string().contains("AdministrativelyProhibited"));
+    }
+
+    #[test]
+    fn map_channel_request_reply_rejects_unexpected_message() {
+        let err = map_channel_request_reply(
+            "execute remote command",
+            Some(ChannelMsg::ExitStatus { exit_status: 0 }),
+        )
+        .expect_err("unexpected message");
+        assert!(err.to_string().contains("exit_status"));
     }
 }

--- a/kaos/tests/exec_options.rs
+++ b/kaos/tests/exec_options.rs
@@ -1,0 +1,147 @@
+use std::collections::BTreeMap;
+
+use anyhow::Result;
+use kaos::{AsyncReadable, ExecOptions, Kaos, LocalKaos};
+use tokio::sync::Mutex;
+
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: tests serialize environment mutations via ENV_LOCK.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prev }
+    }
+
+    fn remove(key: &'static str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: tests serialize environment mutations via ENV_LOCK.
+        unsafe {
+            std::env::remove_var(key);
+        }
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = &self.prev {
+            // SAFETY: tests serialize environment mutations via ENV_LOCK.
+            unsafe {
+                std::env::set_var(self.key, prev);
+            }
+        } else {
+            // SAFETY: tests serialize environment mutations via ENV_LOCK.
+            unsafe {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+fn print_env_command(key: &str) -> Vec<String> {
+    #[cfg(windows)]
+    {
+        vec![
+            "powershell.exe".to_string(),
+            "-Command".to_string(),
+            format!("[Console]::Out.Write($env:{key})"),
+        ]
+    }
+
+    #[cfg(not(windows))]
+    {
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!("printf '%s' \"${key}\""),
+        ]
+    }
+}
+
+async fn read_all(stream: &mut dyn AsyncReadable) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    loop {
+        let chunk = stream.read(1024).await?;
+        if chunk.is_empty() {
+            break;
+        }
+        output.extend_from_slice(&chunk);
+    }
+    Ok(output)
+}
+
+async fn run_command(args: &[String], options: ExecOptions) -> Result<String> {
+    let kaos = LocalKaos::new();
+    let mut process = kaos.exec(args, options).await?;
+    let stdout = match process.take_stdout() {
+        Some(mut stdout) => read_all(stdout.as_mut()).await?,
+        None => read_all(process.stdout()).await?,
+    };
+    let exit_code = process.wait().await?;
+    assert_eq!(exit_code, 0);
+    Ok(String::from_utf8(stdout).expect("stdout utf-8"))
+}
+
+#[tokio::test]
+async fn exec_options_adds_child_environment_variables() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = EnvGuard::remove("KAOS_EXEC_CHILD_ONLY");
+
+    let args = print_env_command("KAOS_EXEC_CHILD_ONLY");
+    let output = run_command(
+        &args,
+        ExecOptions {
+            env_overrides: BTreeMap::from([(
+                "KAOS_EXEC_CHILD_ONLY".to_string(),
+                "child-value".to_string(),
+            )]),
+        },
+    )
+    .await
+    .expect("run command");
+
+    assert_eq!(output, "child-value");
+}
+
+#[tokio::test]
+async fn exec_options_overrides_inherited_environment_values() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = EnvGuard::set("KAOS_EXEC_OVERRIDE", "parent-value");
+
+    let args = print_env_command("KAOS_EXEC_OVERRIDE");
+    let output = run_command(
+        &args,
+        ExecOptions {
+            env_overrides: BTreeMap::from([(
+                "KAOS_EXEC_OVERRIDE".to_string(),
+                "child-value".to_string(),
+            )]),
+        },
+    )
+    .await
+    .expect("run command");
+
+    assert_eq!(output, "child-value");
+}
+
+#[tokio::test]
+async fn empty_exec_options_preserve_inherited_environment() {
+    let _lock = ENV_LOCK.lock().await;
+    let _guard = EnvGuard::set("KAOS_EXEC_INHERITED", "parent-value");
+
+    let args = print_env_command("KAOS_EXEC_INHERITED");
+    let output = run_command(&args, ExecOptions::default())
+        .await
+        .expect("run command");
+
+    assert_eq!(output, "parent-value");
+}

--- a/kimi-agent/tests/create_llm.rs
+++ b/kimi-agent/tests/create_llm.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use anyhow::anyhow;
 use kaos::{
-    CurrentKaosToken, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos, StrOrKaosPath,
-    reset_current_kaos, set_current_kaos, with_current_kaos_scope,
+    CurrentKaosToken, ExecOptions, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos,
+    StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
 };
 use serde_json::json;
 use tempfile::TempDir;
@@ -156,8 +156,12 @@ impl Kaos for BackendEnvKaos {
         Ok(self.env.get(key).cloned())
     }
 
-    async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn KaosProcess>> {
-        self.inner.exec(args).await
+    async fn exec(
+        &self,
+        args: &[String],
+        _options: ExecOptions,
+    ) -> anyhow::Result<Box<dyn KaosProcess>> {
+        self.inner.exec(args, ExecOptions::default()).await
     }
 }
 

--- a/kimi-agent/tests/environment.rs
+++ b/kimi-agent/tests/environment.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use kaos::{
-    CurrentKaosToken, Kaos, KaosPath, KaosPlatform, KaosProcess, LineStream, LocalKaos,
-    StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
+    CurrentKaosToken, ExecOptions, Kaos, KaosPath, KaosPlatform, KaosProcess, LineStream,
+    LocalKaos, StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
 };
 use kimi_agent::utils::Environment;
 use tempfile::TempDir;
@@ -112,8 +112,12 @@ impl Kaos for EnvOnlyKaos {
         Ok(self.env.get(key).cloned())
     }
 
-    async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn KaosProcess>> {
-        self.inner.exec(args).await
+    async fn exec(
+        &self,
+        args: &[String],
+        _options: ExecOptions,
+    ) -> anyhow::Result<Box<dyn KaosProcess>> {
+        self.inner.exec(args, ExecOptions::default()).await
     }
 }
 

--- a/kimi-agent/tests/skill.rs
+++ b/kimi-agent/tests/skill.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use tempfile::TempDir;
 
 use kaos::{
-    CurrentKaosToken, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos, StrOrKaosPath,
-    reset_current_kaos, set_current_kaos, with_current_kaos_scope,
+    CurrentKaosToken, ExecOptions, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos,
+    StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
 };
 use kimi_agent::skill::{
     Skill, SkillMcpServer, SkillType, discover_skills, discover_skills_from_roots,
@@ -109,8 +109,12 @@ impl Kaos for FixedHomeKaos {
         self.inner.env_var(key).await
     }
 
-    async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn KaosProcess>> {
-        self.inner.exec(args).await
+    async fn exec(
+        &self,
+        args: &[String],
+        _options: ExecOptions,
+    ) -> anyhow::Result<Box<dyn KaosProcess>> {
+        self.inner.exec(args, ExecOptions::default()).await
     }
 }
 

--- a/kimi-agent/tests/tool_test_utils.rs
+++ b/kimi-agent/tests/tool_test_utils.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use kaos::{
-    CurrentKaosToken, Kaos, KaosPath, LocalKaos, get_current_kaos, reset_current_kaos,
+    CurrentKaosToken, ExecOptions, Kaos, KaosPath, LocalKaos, get_current_kaos, reset_current_kaos,
     set_current_kaos,
 };
 use kimi_agent::config::{
@@ -248,8 +248,12 @@ impl Kaos for TestKaos {
         self.inner.env_var(key).await
     }
 
-    async fn exec(&self, args: &[String]) -> anyhow::Result<Box<dyn kaos::KaosProcess>> {
-        self.inner.exec(args).await
+    async fn exec(
+        &self,
+        args: &[String],
+        _options: ExecOptions,
+    ) -> anyhow::Result<Box<dyn kaos::KaosProcess>> {
+        self.inner.exec(args, ExecOptions::default()).await
     }
 }
 


### PR DESCRIPTION
## Summary
- add `ExecOptions` to Rust kaos exec APIs while keeping the existing convenience helper
- implement child-process env override support for LocalKaos and SshKaos
- add kaos-level tests for exec env overlay behavior and adapt test Kaos implementations
- document the OpenSSH `AcceptEnv` caveat for SSH env overrides

## Validation
- cargo fmt
- cargo test -p kaos
- cargo test -p kimi-agent
- cargo clippy --workspace --all-targets

Closes #11
