### PR TITLE
Sync builtin skills into managed Kaos directories

### DIFF
--- a/kaos/src/lib.rs
+++ b/kaos/src/lib.rs
@@ -119,6 +119,10 @@ pub trait Kaos: Send + Sync {
         }
     }
 
+    fn app_state_dir(&self, app_name: &str) -> KaosPath {
+        self.home().joinpath(&format!(".{app_name}"))
+    }
+
     fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath;
     fn home(&self) -> KaosPath;
     fn cwd(&self) -> KaosPath;

--- a/kaos/src/local.rs
+++ b/kaos/src/local.rs
@@ -216,6 +216,16 @@ impl Kaos for LocalKaos {
         KaosPath::from(dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")))
     }
 
+    fn app_state_dir(&self, app_name: &str) -> KaosPath {
+        let env_key = format!("{}_SHARE_DIR", app_name.to_ascii_uppercase());
+        if let Some(path) = std::env::var_os(&env_key)
+            && !path.is_empty()
+        {
+            return KaosPath::from(PathBuf::from(path));
+        }
+        self.home().joinpath(&format!(".{app_name}"))
+    }
+
     fn cwd(&self) -> KaosPath {
         KaosPath::from(std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
     }
@@ -548,7 +558,7 @@ fn system_time_to_f64(time: SystemTime) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::LocalKaos;
-    use crate::Kaos;
+    use crate::{Kaos, KaosPath};
     use tokio::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::const_new(());
@@ -616,5 +626,22 @@ mod tests {
                 .expect("read env"),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn app_state_dir_prefers_share_dir_env_override() {
+        let _lock = ENV_LOCK.lock().await;
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        let share_dir = std::env::temp_dir().join(format!("kaos-kimi-share-{unique}"));
+        let _guard = EnvGuard::set(
+            "KIMI_SHARE_DIR",
+            share_dir.to_str().expect("share dir path"),
+        );
+        let kaos = LocalKaos::new();
+
+        assert_eq!(kaos.app_state_dir("kimi"), KaosPath::from(share_dir));
     }
 }

--- a/kimi-agent/build.rs
+++ b/kimi-agent/build.rs
@@ -1,0 +1,59 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("manifest dir"));
+    let skills_dir = manifest_dir.join("src").join("skills");
+    println!("cargo:rerun-if-changed={}", skills_dir.display());
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR"));
+    let dest = out_dir.join("builtin_skills.rs");
+    let files = collect_files(&skills_dir, &skills_dir);
+    let generated = render_builtin_assets(&files);
+    fs::write(&dest, generated).expect("write builtin skills manifest");
+}
+
+fn collect_files(root: &Path, dir: &Path) -> Vec<(String, PathBuf)> {
+    let mut entries = Vec::new();
+    let mut children: Vec<_> = fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("read_dir {}: {err}", dir.display()))
+        .map(|entry| entry.unwrap_or_else(|err| panic!("read_dir entry {}: {err}", dir.display())))
+        .collect();
+    children.sort_by_key(|entry| entry.path());
+
+    for child in children {
+        let path = child.path();
+        if child
+            .file_type()
+            .unwrap_or_else(|err| panic!("file_type {}: {err}", path.display()))
+            .is_dir()
+        {
+            entries.extend(collect_files(root, &path));
+            continue;
+        }
+        let relative = path
+            .strip_prefix(root)
+            .unwrap_or_else(|err| panic!("strip_prefix {}: {err}", path.display()))
+            .to_string_lossy()
+            .replace('\\', "/");
+        entries.push((relative, path));
+    }
+
+    entries
+}
+
+fn render_builtin_assets(files: &[(String, PathBuf)]) -> String {
+    let mut generated = String::from("static BUILTIN_SKILL_FILES: &[EmbeddedFile] = &[\n");
+    for (relative, absolute) in files {
+        generated.push_str("    EmbeddedFile {\n");
+        generated.push_str(&format!("        relative_path: {relative:?},\n"));
+        generated.push_str(&format!(
+            "        contents: include_bytes!(r#\"{}\"#),\n",
+            absolute.display()
+        ));
+        generated.push_str("    },\n");
+    }
+    generated.push_str("];\n");
+    generated
+}

--- a/kimi-agent/src/cli/mod.rs
+++ b/kimi-agent/src/cli/mod.rs
@@ -161,7 +161,7 @@ pub struct Cli {
     #[arg(
         long = "skills-dir",
         value_name = "PATH",
-        help = "Path to the skills directory. Overrides discovery."
+        help = "Path to the skills directory. Disables builtin/user/project discovery and loads only this directory."
     )]
     skills_dir: Option<String>,
 

--- a/kimi-agent/src/skill/AGENTS.md
+++ b/kimi-agent/src/skill/AGENTS.md
@@ -9,6 +9,9 @@
 ## Compatibility Rules
 
 - Skills are discovered from layered roots (builtin → user → project) with later roots overriding.
+- Builtin skills are embedded into the binary and synchronized into a managed directory under the active Kaos backend app state dir before discovery runs.
+- User/project skills remain Kaos-backed directories discovered from the active backend filesystem.
+- Builtin sync is best-effort: if the managed directory cannot be prepared, discovery skips builtin skills and continues.
 - Flow skills require a `mermaid` or `d2` fenced code block in `SKILL.md`.
 - Invalid flow parsing falls back to `standard` skill type.
 - Skill frontmatter may include `mcp` server definitions (`stdio`/`http`) for runtime dynamic loading.

--- a/kimi-agent/src/skill/builtin.rs
+++ b/kimi-agent/src/skill/builtin.rs
@@ -1,0 +1,436 @@
+use anyhow::{Context, Result};
+use kaos::{KaosPath, get_current_kaos};
+use tracing::debug;
+
+#[derive(Clone, Copy)]
+struct EmbeddedFile {
+    relative_path: &'static str,
+    contents: &'static [u8],
+}
+
+include!(concat!(env!("OUT_DIR"), "/builtin_skills.rs"));
+
+const READY_MARKER_FILE: &str = ".bundle-ready";
+
+pub async fn prepare_builtin_skills_root() -> Result<KaosPath> {
+    let bundle_id = builtin_bundle_id();
+    let root = builtin_bundle_root(&bundle_id);
+    if is_materialized_bundle_usable(&root, &bundle_id, BUILTIN_SKILL_FILES).await? {
+        debug!(
+            root = %root.to_string_lossy(),
+            files = BUILTIN_SKILL_FILES.len(),
+            "Reusing builtin skills bundle"
+        );
+        return Ok(root);
+    }
+
+    materialize_embedded_files(&root, BUILTIN_SKILL_FILES).await?;
+    write_ready_marker(&root, &bundle_id).await?;
+    debug!(
+        root = %root.to_string_lossy(),
+        files = BUILTIN_SKILL_FILES.len(),
+        "Materialized builtin skills bundle"
+    );
+    Ok(root)
+}
+
+fn builtin_bundle_id() -> String {
+    let mut data = Vec::new();
+    for file in BUILTIN_SKILL_FILES {
+        data.extend_from_slice(file.relative_path.as_bytes());
+        data.push(0);
+        data.extend_from_slice(file.contents);
+        data.push(0);
+    }
+    format!("{:x}", md5::compute(data))
+}
+
+fn builtin_bundle_root(bundle_id: &str) -> KaosPath {
+    get_current_kaos().app_state_dir("kimi") / "builtin-skills" / bundle_id
+}
+
+fn ready_marker_path(root: &KaosPath) -> KaosPath {
+    root.clone() / READY_MARKER_FILE
+}
+
+async fn is_materialized_bundle_usable(
+    root: &KaosPath,
+    bundle_id: &str,
+    files: &[EmbeddedFile],
+) -> Result<bool> {
+    if !root.is_dir(true).await {
+        return Ok(false);
+    }
+
+    let ready_marker = ready_marker_path(root);
+    if let Ok(marker) = ready_marker.read_text().await
+        && marker.trim() == bundle_id
+    {
+        return Ok(true);
+    }
+
+    let platform = get_current_kaos().platform();
+    for file in files {
+        let path = path_from_relative(root, file.relative_path);
+        let contents = match path.read_bytes(None).await {
+            Ok(contents) => contents,
+            Err(_) => return Ok(false),
+        };
+        if contents != file.contents {
+            return Ok(false);
+        }
+        if platform.os != "windows" && is_script_asset(file.relative_path) {
+            let stat = match path.stat(true).await {
+                Ok(stat) => stat,
+                Err(_) => return Ok(false),
+            };
+            if stat.st_mode & 0o111 == 0 {
+                return Ok(false);
+            }
+        }
+    }
+
+    Ok(true)
+}
+
+async fn materialize_embedded_files(root: &KaosPath, files: &[EmbeddedFile]) -> Result<()> {
+    root.mkdir(true, true).await.with_context(|| {
+        format!(
+            "Failed to create builtin skills root {}",
+            root.to_string_lossy()
+        )
+    })?;
+
+    let platform = get_current_kaos().platform();
+    for file in files {
+        let path = path_from_relative(root, file.relative_path);
+        let parent = path.parent();
+        parent.mkdir(true, true).await.with_context(|| {
+            format!(
+                "Failed to create parent directory {}",
+                parent.to_string_lossy()
+            )
+        })?;
+        path.write_bytes(file.contents).await.with_context(|| {
+            format!(
+                "Failed to write builtin skill asset {}",
+                path.to_string_lossy()
+            )
+        })?;
+        if platform.os != "windows" && is_script_asset(file.relative_path) {
+            path.chmod(0o755).await.with_context(|| {
+                format!("Failed to chmod builtin script {}", path.to_string_lossy())
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn write_ready_marker(root: &KaosPath, bundle_id: &str) -> Result<()> {
+    let ready_marker = ready_marker_path(root);
+    ready_marker.write_text(bundle_id).await.with_context(|| {
+        format!(
+            "Failed to write builtin bundle marker {}",
+            ready_marker.to_string_lossy()
+        )
+    })?;
+    Ok(())
+}
+
+fn path_from_relative(root: &KaosPath, relative_path: &str) -> KaosPath {
+    relative_path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .fold(root.clone(), |path, segment| path.joinpath(segment))
+}
+
+fn is_script_asset(relative_path: &str) -> bool {
+    let mut components = relative_path
+        .split('/')
+        .filter(|segment| !segment.is_empty());
+    let _skill_name = components.next();
+    matches!(components.next(), Some("scripts"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        EmbeddedFile, READY_MARKER_FILE, builtin_bundle_id, builtin_bundle_root,
+        is_materialized_bundle_usable, is_script_asset, materialize_embedded_files,
+        write_ready_marker,
+    };
+    use std::sync::Arc;
+
+    use kaos::{
+        CurrentKaosToken, ExecOptions, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos,
+        StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
+    };
+    use tempfile::TempDir;
+
+    struct FixedHomeKaos {
+        inner: LocalKaos,
+        home: KaosPath,
+    }
+
+    impl FixedHomeKaos {
+        fn new(home: KaosPath) -> Self {
+            Self {
+                inner: LocalKaos::new(),
+                home,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Kaos for FixedHomeKaos {
+        fn name(&self) -> &str {
+            "local"
+        }
+
+        fn platform(&self) -> kaos::KaosPlatform {
+            self.inner.platform()
+        }
+
+        fn normpath(&self, path: &StrOrKaosPath<'_>) -> KaosPath {
+            self.inner.normpath(path)
+        }
+
+        fn home(&self) -> KaosPath {
+            self.home.clone()
+        }
+
+        fn app_state_dir(&self, app_name: &str) -> KaosPath {
+            self.home().joinpath(&format!(".{app_name}"))
+        }
+
+        fn cwd(&self) -> KaosPath {
+            self.inner.cwd()
+        }
+
+        async fn chdir(&self, path: &KaosPath) -> anyhow::Result<()> {
+            self.inner.chdir(path).await
+        }
+
+        async fn stat(
+            &self,
+            path: &KaosPath,
+            follow_symlinks: bool,
+        ) -> anyhow::Result<kaos::StatResult> {
+            self.inner.stat(path, follow_symlinks).await
+        }
+
+        async fn iterdir(&self, path: &KaosPath) -> anyhow::Result<Vec<KaosPath>> {
+            self.inner.iterdir(path).await
+        }
+
+        async fn glob(
+            &self,
+            path: &KaosPath,
+            pattern: &str,
+            case_sensitive: bool,
+        ) -> anyhow::Result<Vec<KaosPath>> {
+            self.inner.glob(path, pattern, case_sensitive).await
+        }
+
+        async fn read_bytes(
+            &self,
+            path: &KaosPath,
+            limit: Option<usize>,
+        ) -> anyhow::Result<Vec<u8>> {
+            self.inner.read_bytes(path, limit).await
+        }
+
+        async fn read_text(&self, path: &KaosPath) -> anyhow::Result<String> {
+            self.inner.read_text(path).await
+        }
+
+        async fn read_lines(&self, path: &KaosPath) -> anyhow::Result<Vec<String>> {
+            self.inner.read_lines(path).await
+        }
+
+        async fn read_lines_stream(&self, path: &KaosPath) -> anyhow::Result<LineStream> {
+            self.inner.read_lines_stream(path).await
+        }
+
+        async fn write_bytes(&self, path: &KaosPath, data: &[u8]) -> anyhow::Result<usize> {
+            self.inner.write_bytes(path, data).await
+        }
+
+        async fn write_text(
+            &self,
+            path: &KaosPath,
+            data: &str,
+            append: bool,
+        ) -> anyhow::Result<usize> {
+            self.inner.write_text(path, data, append).await
+        }
+
+        async fn chmod(&self, path: &KaosPath, mode: u32) -> anyhow::Result<()> {
+            self.inner.chmod(path, mode).await
+        }
+
+        async fn mkdir(
+            &self,
+            path: &KaosPath,
+            parents: bool,
+            exist_ok: bool,
+        ) -> anyhow::Result<()> {
+            self.inner.mkdir(path, parents, exist_ok).await
+        }
+
+        async fn env_var(&self, key: &str) -> anyhow::Result<Option<String>> {
+            self.inner.env_var(key).await
+        }
+
+        async fn exec(
+            &self,
+            args: &[String],
+            _options: ExecOptions,
+        ) -> anyhow::Result<Box<dyn KaosProcess>> {
+            self.inner.exec(args, ExecOptions::default()).await
+        }
+    }
+
+    struct FixedHomeKaosGuard {
+        token: Option<CurrentKaosToken>,
+    }
+
+    impl FixedHomeKaosGuard {
+        fn new(home: KaosPath) -> Self {
+            let kaos = Arc::new(FixedHomeKaos::new(home));
+            let token = set_current_kaos(kaos);
+            Self { token: Some(token) }
+        }
+    }
+
+    impl Drop for FixedHomeKaosGuard {
+        fn drop(&mut self) {
+            if let Some(token) = self.token.take() {
+                reset_current_kaos(token);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_is_script_asset_matches_scripts_subtree() {
+        assert!(is_script_asset("skill/scripts/run.sh"));
+        assert!(is_script_asset("skill/scripts/bin/run.py"));
+        assert!(!is_script_asset("skill/references/ref.md"));
+        assert!(!is_script_asset("skill/SKILL.md"));
+    }
+
+    #[tokio::test]
+    async fn test_materialize_embedded_files_writes_nested_assets() {
+        with_current_kaos_scope(async {
+            let tmp = TempDir::new().expect("temp dir");
+            let home_dir = tmp.path().join("home");
+            std::fs::create_dir_all(&home_dir).expect("create home dir");
+            let _guard = FixedHomeKaosGuard::new(KaosPath::unsafe_from_local_path(&home_dir));
+            let root = KaosPath::home() / ".kimi" / "builtin-skills" / "test-bundle";
+            let assets = [
+                EmbeddedFile {
+                    relative_path: "demo/SKILL.md",
+                    contents: b"# demo\n",
+                },
+                EmbeddedFile {
+                    relative_path: "demo/references/ref.md",
+                    contents: b"reference\n",
+                },
+                EmbeddedFile {
+                    relative_path: "demo/scripts/run.sh",
+                    contents: b"#!/bin/sh\necho ok\n",
+                },
+            ];
+
+            materialize_embedded_files(&root, &assets)
+                .await
+                .expect("materialize builtin files");
+
+            assert_eq!(
+                (root.clone() / "demo" / "SKILL.md")
+                    .read_text()
+                    .await
+                    .expect("read skill"),
+                "# demo\n"
+            );
+            assert_eq!(
+                (root.clone() / "demo" / "references" / "ref.md")
+                    .read_text()
+                    .await
+                    .expect("read ref"),
+                "reference\n"
+            );
+
+            if !cfg!(windows) {
+                let script_stat = (root / "demo" / "scripts" / "run.sh")
+                    .stat(true)
+                    .await
+                    .expect("script stat");
+                assert_eq!(script_stat.st_mode & 0o777, 0o755);
+            }
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_is_materialized_bundle_usable_accepts_ready_marker() {
+        with_current_kaos_scope(async {
+            let tmp = TempDir::new().expect("temp dir");
+            let home_dir = tmp.path().join("home");
+            std::fs::create_dir_all(&home_dir).expect("create home dir");
+            let _guard = FixedHomeKaosGuard::new(KaosPath::unsafe_from_local_path(&home_dir));
+            let bundle_id = builtin_bundle_id();
+            let root = builtin_bundle_root(&bundle_id);
+
+            root.mkdir(true, true).await.expect("create root");
+            write_ready_marker(&root, &bundle_id)
+                .await
+                .expect("write ready marker");
+
+            assert!(
+                is_materialized_bundle_usable(&root, &bundle_id, &[] as &[EmbeddedFile])
+                    .await
+                    .expect("check bundle usability")
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_is_materialized_bundle_usable_validates_bundle_without_marker() {
+        with_current_kaos_scope(async {
+            let tmp = TempDir::new().expect("temp dir");
+            let home_dir = tmp.path().join("home");
+            std::fs::create_dir_all(&home_dir).expect("create home dir");
+            let _guard = FixedHomeKaosGuard::new(KaosPath::unsafe_from_local_path(&home_dir));
+            let root = KaosPath::home() / ".kimi" / "builtin-skills" / "test-bundle";
+            let assets = [
+                EmbeddedFile {
+                    relative_path: "demo/SKILL.md",
+                    contents: b"# demo\n",
+                },
+                EmbeddedFile {
+                    relative_path: "demo/scripts/run.sh",
+                    contents: b"#!/bin/sh\necho ok\n",
+                },
+            ];
+
+            materialize_embedded_files(&root, &assets)
+                .await
+                .expect("materialize builtin files");
+
+            let ready_marker = root.clone() / READY_MARKER_FILE;
+            if ready_marker.exists(true).await {
+                std::fs::remove_file(ready_marker.unsafe_to_local_path()).expect("remove marker");
+            }
+
+            assert!(
+                is_materialized_bundle_usable(&root, "unused-bundle-id", &assets)
+                    .await
+                    .expect("check bundle usability")
+            );
+        })
+        .await;
+    }
+}

--- a/kimi-agent/src/skill/mod.rs
+++ b/kimi-agent/src/skill/mod.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
 
-use kaos::{KaosPath, get_current_kaos};
+use kaos::KaosPath;
 use serde::Deserialize;
 use serde_yaml::Value;
 use tracing::{error, info, warn};
@@ -11,6 +10,7 @@ use crate::skill::flow::mermaid::parse_mermaid_flowchart;
 use crate::skill::flow::{Flow, FlowError};
 use crate::utils::parse_frontmatter;
 
+mod builtin;
 pub mod flow;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -118,12 +118,6 @@ pub fn get_skills_dir() -> KaosPath {
     KaosPath::home() / ".config" / "agents" / "skills"
 }
 
-pub fn get_builtin_skills_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("src")
-        .join("skills")
-}
-
 pub fn get_user_skills_dir_candidates() -> Vec<KaosPath> {
     vec![
         KaosPath::home() / ".config" / "agents" / "skills",
@@ -141,11 +135,6 @@ pub fn get_project_skills_dir_candidates(work_dir: &KaosPath) -> Vec<KaosPath> {
         work_dir.clone() / ".claude" / "skills",
         work_dir.clone() / ".codex" / "skills",
     ]
-}
-
-fn supports_builtin_skills() -> bool {
-    let current = get_current_kaos().name().to_string();
-    matches!(current.as_str(), "local" | "acp")
 }
 
 pub async fn find_first_existing_dir(candidates: &[KaosPath]) -> Option<KaosPath> {
@@ -169,13 +158,14 @@ pub async fn resolve_skills_roots(
     work_dir: &KaosPath,
     skills_dir_override: Option<KaosPath>,
 ) -> Vec<KaosPath> {
-    let mut roots = Vec::new();
-    if supports_builtin_skills() {
-        roots.push(KaosPath::unsafe_from_local_path(&get_builtin_skills_dir()));
-    }
     if let Some(override_dir) = skills_dir_override {
-        roots.push(override_dir);
-        return roots;
+        return vec![override_dir];
+    }
+
+    let mut roots = Vec::new();
+    match builtin::prepare_builtin_skills_root().await {
+        Ok(root) => roots.push(root),
+        Err(err) => warn!("Skipping builtin skills: {err}"),
     }
     if let Some(user_dir) = find_user_skills_dir().await {
         roots.push(user_dir);

--- a/kimi-agent/src/skills/skill-creator/SKILL.md
+++ b/kimi-agent/src/skills/skill-creator/SKILL.md
@@ -201,7 +201,9 @@ Kimi reads REDLINING.md or OOXML.md only when the user needs those features.
 ## Skill Locations and Discovery
 
 Kimi Code CLI loads skills in layers (built-in -> user -> project). Within each layer, it uses the
-first existing directory in priority order. Built-in skills only load for LocalKaos or ACPKaos.
+first existing directory in priority order. Built-in skills are always available because Kimi syncs
+them into a managed directory on the active Kaos backend before discovery. If that managed
+directory cannot be prepared, Kimi skips built-ins and continues with the remaining layers.
 
 **User level** (by priority):
 - `~/.config/agents/skills/` (recommended)
@@ -211,8 +213,7 @@ first existing directory in priority order. Built-in skills only load for LocalK
 **Project level**:
 - `.agents/skills/`
 
-`--skills-dir` overrides discovery and loads only that directory (built-ins still load when
-supported).
+`--skills-dir` disables builtin/user/project discovery and loads only the specified directory.
 
 ## Skill Creation Process
 

--- a/kimi-agent/tests/skill.rs
+++ b/kimi-agent/tests/skill.rs
@@ -1,35 +1,125 @@
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tempfile::TempDir;
+use tokio::sync::Mutex as AsyncMutex;
 
 use kaos::{
     CurrentKaosToken, ExecOptions, Kaos, KaosPath, KaosProcess, LineStream, LocalKaos,
     StrOrKaosPath, reset_current_kaos, set_current_kaos, with_current_kaos_scope,
 };
+use kimi_agent::config::get_default_config;
+use kimi_agent::metadata::WorkDirMeta;
+use kimi_agent::session::Session;
 use kimi_agent::skill::{
     Skill, SkillMcpServer, SkillType, discover_skills, discover_skills_from_roots,
-    find_user_skills_dir, get_builtin_skills_dir, resolve_skills_roots,
+    find_user_skills_dir, resolve_skills_roots,
 };
+use kimi_agent::soul::agent::Runtime;
+use kimi_agent::wire::WireFile;
 
-struct FixedHomeKaos {
-    inner: LocalKaos,
-    home: KaosPath,
+static ENV_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
+
+struct EnvGuard {
+    key: &'static str,
+    prev: Option<String>,
 }
 
-impl FixedHomeKaos {
-    fn new(home: KaosPath) -> Self {
-        Self {
-            inner: LocalKaos::new(),
-            home,
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(prev) = &self.prev {
+            // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+            unsafe {
+                std::env::set_var(self.key, prev);
+            }
+        } else {
+            // SAFETY: tests serialize env access via ENV_LOCK to avoid races.
+            unsafe {
+                std::env::remove_var(self.key);
+            }
         }
     }
 }
 
+struct ScopedKaos {
+    inner: LocalKaos,
+    backend_name: &'static str,
+    root: KaosPath,
+    home: KaosPath,
+    cwd: Mutex<KaosPath>,
+    fail_managed_dir_writes: bool,
+}
+
+impl ScopedKaos {
+    fn new(
+        backend_name: &'static str,
+        root: KaosPath,
+        home: KaosPath,
+        cwd: KaosPath,
+        fail_managed_dir_writes: bool,
+    ) -> Self {
+        Self {
+            inner: LocalKaos::new(),
+            backend_name,
+            root,
+            home,
+            cwd: Mutex::new(cwd),
+            fail_managed_dir_writes,
+        }
+    }
+
+    fn resolve_path(&self, path: &KaosPath) -> KaosPath {
+        let absolute = if path.is_absolute() {
+            path.clone()
+        } else {
+            self.cwd.lock().unwrap().clone() / path
+        };
+        self.inner.normpath(&StrOrKaosPath::KaosPath(&absolute))
+    }
+
+    fn ensure_within_root(&self, path: &KaosPath) -> anyhow::Result<()> {
+        let resolved = self.resolve_path(path);
+        if resolved.relative_to(&self.root).is_ok() {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "Path {} escapes test root {}",
+            resolved.to_string_lossy(),
+            self.root.to_string_lossy()
+        );
+    }
+
+    fn ensure_managed_dir_writable(&self, path: &KaosPath) -> anyhow::Result<()> {
+        if !self.fail_managed_dir_writes {
+            return Ok(());
+        }
+        let resolved = self.resolve_path(path);
+        let managed_dir = self.app_state_dir("kimi");
+        if resolved.relative_to(&managed_dir).is_ok() {
+            anyhow::bail!(
+                "Managed app state dir is read-only: {}",
+                managed_dir.to_string_lossy()
+            );
+        }
+        Ok(())
+    }
+}
+
 #[async_trait::async_trait]
-impl Kaos for FixedHomeKaos {
+impl Kaos for ScopedKaos {
     fn name(&self) -> &str {
-        "local"
+        self.backend_name
     }
 
     fn platform(&self) -> kaos::KaosPlatform {
@@ -45,11 +135,13 @@ impl Kaos for FixedHomeKaos {
     }
 
     fn cwd(&self) -> KaosPath {
-        self.inner.cwd()
+        self.cwd.lock().unwrap().clone()
     }
 
     async fn chdir(&self, path: &KaosPath) -> anyhow::Result<()> {
-        self.inner.chdir(path).await
+        self.ensure_within_root(path)?;
+        *self.cwd.lock().unwrap() = self.resolve_path(path);
+        Ok(())
     }
 
     async fn stat(
@@ -57,10 +149,12 @@ impl Kaos for FixedHomeKaos {
         path: &KaosPath,
         follow_symlinks: bool,
     ) -> anyhow::Result<kaos::StatResult> {
+        self.ensure_within_root(path)?;
         self.inner.stat(path, follow_symlinks).await
     }
 
     async fn iterdir(&self, path: &KaosPath) -> anyhow::Result<Vec<KaosPath>> {
+        self.ensure_within_root(path)?;
         self.inner.iterdir(path).await
     }
 
@@ -70,38 +164,51 @@ impl Kaos for FixedHomeKaos {
         pattern: &str,
         case_sensitive: bool,
     ) -> anyhow::Result<Vec<KaosPath>> {
+        self.ensure_within_root(path)?;
         self.inner.glob(path, pattern, case_sensitive).await
     }
 
     async fn read_bytes(&self, path: &KaosPath, limit: Option<usize>) -> anyhow::Result<Vec<u8>> {
+        self.ensure_within_root(path)?;
         self.inner.read_bytes(path, limit).await
     }
 
     async fn read_text(&self, path: &KaosPath) -> anyhow::Result<String> {
+        self.ensure_within_root(path)?;
         self.inner.read_text(path).await
     }
 
     async fn read_lines(&self, path: &KaosPath) -> anyhow::Result<Vec<String>> {
+        self.ensure_within_root(path)?;
         self.inner.read_lines(path).await
     }
 
     async fn read_lines_stream(&self, path: &KaosPath) -> anyhow::Result<LineStream> {
+        self.ensure_within_root(path)?;
         self.inner.read_lines_stream(path).await
     }
 
     async fn write_bytes(&self, path: &KaosPath, data: &[u8]) -> anyhow::Result<usize> {
+        self.ensure_within_root(path)?;
+        self.ensure_managed_dir_writable(path)?;
         self.inner.write_bytes(path, data).await
     }
 
     async fn write_text(&self, path: &KaosPath, data: &str, append: bool) -> anyhow::Result<usize> {
+        self.ensure_within_root(path)?;
+        self.ensure_managed_dir_writable(path)?;
         self.inner.write_text(path, data, append).await
     }
 
     async fn chmod(&self, path: &KaosPath, mode: u32) -> anyhow::Result<()> {
+        self.ensure_within_root(path)?;
+        self.ensure_managed_dir_writable(path)?;
         self.inner.chmod(path, mode).await
     }
 
     async fn mkdir(&self, path: &KaosPath, parents: bool, exist_ok: bool) -> anyhow::Result<()> {
+        self.ensure_within_root(path)?;
+        self.ensure_managed_dir_writable(path)?;
         self.inner.mkdir(path, parents, exist_ok).await
     }
 
@@ -123,8 +230,20 @@ struct FixedHomeKaosGuard {
 }
 
 impl FixedHomeKaosGuard {
-    fn new(home: KaosPath) -> Self {
-        let kaos = Arc::new(FixedHomeKaos::new(home));
+    fn new(
+        backend_name: &'static str,
+        root: KaosPath,
+        home: KaosPath,
+        cwd: KaosPath,
+        fail_managed_dir_writes: bool,
+    ) -> Self {
+        let kaos = Arc::new(ScopedKaos::new(
+            backend_name,
+            root,
+            home,
+            cwd,
+            fail_managed_dir_writes,
+        ));
         let token = set_current_kaos(kaos);
         Self { token: Some(token) }
     }
@@ -141,6 +260,36 @@ impl Drop for FixedHomeKaosGuard {
 fn write_skill(skill_dir: &Path, content: &str) {
     std::fs::create_dir_all(skill_dir).expect("create skill dir");
     std::fs::write(skill_dir.join("SKILL.md"), content).expect("write skill");
+}
+
+fn assert_is_managed_builtin_root(root: &KaosPath, home: &KaosPath) {
+    let managed_prefix = home.clone() / ".kimi" / "builtin-skills";
+    assert!(
+        root.relative_to(&managed_prefix).is_ok(),
+        "expected {} to live under {}",
+        root.to_string_lossy(),
+        managed_prefix.to_string_lossy()
+    );
+}
+
+fn build_test_session(work_dir: &KaosPath, share_dir: &Path) -> Session {
+    let work_dir_meta = WorkDirMeta {
+        path: work_dir.to_string_lossy(),
+        kaos: "test".to_string(),
+        last_session_id: None,
+    };
+    let context_file = share_dir.join("context.jsonl");
+    std::fs::write(&context_file, "").expect("context file");
+
+    Session {
+        id: "skill-runtime".to_string(),
+        work_dir: work_dir.clone(),
+        work_dir_meta,
+        context_file,
+        wire_file: WireFile::new(share_dir.join("wire.jsonl")),
+        title: "Skill Runtime".to_string(),
+        updated_at: 0.0,
+    }
 }
 
 #[tokio::test]
@@ -319,25 +468,64 @@ async fn test_discover_skills_from_roots_prefers_later_dirs() {
 async fn test_resolve_skills_roots_uses_layers() {
     with_current_kaos_scope(async {
         let tmp = TempDir::new().expect("temp dir");
-        let home_dir = tmp.path().join("home");
+        let root_dir = tmp.path().join("root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("project");
         std::fs::create_dir_all(&home_dir).expect("create home dir");
-        let _kaos_guard = FixedHomeKaosGuard::new(KaosPath::unsafe_from_local_path(&home_dir));
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard = FixedHomeKaosGuard::new(
+            "local",
+            root_path,
+            home_path.clone(),
+            work_path.clone(),
+            false,
+        );
         let user_dir = home_dir.join(".config/agents/skills");
         std::fs::create_dir_all(&user_dir).expect("create user skills dir");
 
-        let work_dir = tmp.path().join("project");
         let project_dir = work_dir.join(".agents/skills");
         std::fs::create_dir_all(&project_dir).expect("create project skills dir");
 
-        let roots = resolve_skills_roots(&KaosPath::unsafe_from_local_path(&work_dir), None).await;
+        let roots = resolve_skills_roots(&work_path, None).await;
 
-        assert_eq!(
-            roots,
-            vec![
-                KaosPath::unsafe_from_local_path(&get_builtin_skills_dir()),
-                KaosPath::unsafe_from_local_path(&user_dir),
-                KaosPath::unsafe_from_local_path(&project_dir),
-            ]
+        assert_eq!(roots.len(), 3);
+        assert_is_managed_builtin_root(&roots[0], &home_path);
+        assert_eq!(roots[1], KaosPath::unsafe_from_local_path(&user_dir));
+        assert_eq!(roots[2], KaosPath::unsafe_from_local_path(&project_dir));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_resolve_skills_roots_uses_kimi_share_dir_for_local_backend() {
+    let _lock = ENV_LOCK.lock().await;
+    let tmp = TempDir::new().expect("temp dir");
+    let home_dir = tmp.path().join("home");
+    let share_dir = tmp.path().join("share");
+    let work_dir = tmp.path().join("work");
+    std::fs::create_dir_all(&home_dir).expect("create home dir");
+    std::fs::create_dir_all(&share_dir).expect("create share dir");
+    std::fs::create_dir_all(&work_dir).expect("create work dir");
+    let _home = EnvGuard::set("HOME", home_dir.to_str().expect("home path"));
+    let _userprofile = EnvGuard::set("USERPROFILE", home_dir.to_str().expect("home path"));
+    let _share = EnvGuard::set("KIMI_SHARE_DIR", share_dir.to_str().expect("share path"));
+
+    with_current_kaos_scope(async {
+        let token = set_current_kaos(Arc::new(LocalKaos::new()));
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let roots = resolve_skills_roots(&work_path, None).await;
+        reset_current_kaos(token);
+
+        assert!(!roots.is_empty());
+        let managed_prefix = KaosPath::unsafe_from_local_path(&share_dir) / "builtin-skills";
+        assert!(
+            roots[0].relative_to(&managed_prefix).is_ok(),
+            "expected {} to live under {}",
+            roots[0].to_string_lossy(),
+            managed_prefix.to_string_lossy()
         );
     })
     .await;
@@ -345,32 +533,52 @@ async fn test_resolve_skills_roots_uses_layers() {
 
 #[tokio::test]
 async fn test_resolve_skills_roots_respects_override() {
-    let work_dir = TempDir::new().expect("temp dir");
-    let override_dir = work_dir.path().join("override");
-    std::fs::create_dir_all(&override_dir).expect("create override dir");
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("project");
+        let override_dir = work_dir.join("override");
+        std::fs::create_dir_all(&home_dir).expect("create home dir");
+        std::fs::create_dir_all(&override_dir).expect("create override dir");
 
-    let roots = resolve_skills_roots(
-        &KaosPath::unsafe_from_local_path(work_dir.path()),
-        Some(KaosPath::unsafe_from_local_path(&override_dir)),
-    )
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard = FixedHomeKaosGuard::new(
+            "local",
+            root_path,
+            KaosPath::unsafe_from_local_path(&home_dir),
+            work_path.clone(),
+            false,
+        );
+
+        let roots = resolve_skills_roots(
+            &work_path,
+            Some(KaosPath::unsafe_from_local_path(&override_dir)),
+        )
+        .await;
+
+        assert_eq!(roots, vec![KaosPath::unsafe_from_local_path(&override_dir)]);
+    })
     .await;
-
-    assert_eq!(
-        roots,
-        vec![
-            KaosPath::unsafe_from_local_path(&get_builtin_skills_dir()),
-            KaosPath::unsafe_from_local_path(&override_dir),
-        ]
-    );
 }
 
 #[tokio::test]
 async fn test_find_user_skills_dir_uses_agents_candidate() {
     with_current_kaos_scope(async {
         let tmp = TempDir::new().expect("temp dir");
-        let home_dir = tmp.path().join("home");
+        let root_dir = tmp.path().join("root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
         std::fs::create_dir_all(&home_dir).expect("create home dir");
-        let _kaos_guard = FixedHomeKaosGuard::new(KaosPath::unsafe_from_local_path(&home_dir));
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+        let _kaos_guard = FixedHomeKaosGuard::new(
+            "local",
+            KaosPath::unsafe_from_local_path(&root_dir),
+            KaosPath::unsafe_from_local_path(&home_dir),
+            KaosPath::unsafe_from_local_path(&work_dir),
+            false,
+        );
 
         let agents_dir = home_dir.join(".agents/skills");
         std::fs::create_dir_all(&agents_dir).expect("create agents skills dir");
@@ -385,15 +593,226 @@ async fn test_find_user_skills_dir_uses_agents_candidate() {
 async fn test_find_user_skills_dir_uses_codex_candidate() {
     with_current_kaos_scope(async {
         let tmp = TempDir::new().expect("temp dir");
-        let home_dir = tmp.path().join("home");
+        let root_dir = tmp.path().join("root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
         std::fs::create_dir_all(&home_dir).expect("create home dir");
-        let _kaos_guard = FixedHomeKaosGuard::new(KaosPath::unsafe_from_local_path(&home_dir));
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+        let _kaos_guard = FixedHomeKaosGuard::new(
+            "local",
+            KaosPath::unsafe_from_local_path(&root_dir),
+            KaosPath::unsafe_from_local_path(&home_dir),
+            KaosPath::unsafe_from_local_path(&work_dir),
+            false,
+        );
 
         let codex_dir = home_dir.join(".codex/skills");
         std::fs::create_dir_all(&codex_dir).expect("create codex skills dir");
 
         let found = find_user_skills_dir().await.expect("user skills dir");
         assert_eq!(found, KaosPath::unsafe_from_local_path(&codex_dir));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_resolve_skills_roots_materializes_builtin_skills_for_remote_backend() {
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("remote-root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
+        std::fs::create_dir_all(&home_dir).expect("create home dir");
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard = FixedHomeKaosGuard::new(
+            "ssh",
+            root_path,
+            home_path.clone(),
+            work_path.clone(),
+            false,
+        );
+
+        let roots = resolve_skills_roots(&work_path, None).await;
+        assert!(!roots.is_empty());
+        assert_is_managed_builtin_root(&roots[0], &home_path);
+
+        let skills = discover_skills_from_roots(&roots).await;
+        let names: Vec<_> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert!(names.contains(&"kimi-cli-help"));
+        assert!(names.contains(&"skill-creator"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_runtime_create_lists_managed_builtin_skill_paths() {
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("remote-root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
+        let share_dir = tmp.path().join("share");
+        std::fs::create_dir_all(&home_dir).expect("create home dir");
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+        std::fs::create_dir_all(&share_dir).expect("create share dir");
+
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard =
+            FixedHomeKaosGuard::new("ssh", root_path, home_path, work_path.clone(), false);
+
+        let session = build_test_session(&work_path, &share_dir);
+        let runtime = Runtime::create(get_default_config(), None, session, true, None).await;
+
+        assert!(
+            runtime
+                .builtin_args
+                .KIMI_SKILLS
+                .contains(".kimi/builtin-skills/")
+        );
+        assert!(
+            runtime
+                .builtin_args
+                .KIMI_SKILLS
+                .contains("skill-creator/SKILL.md")
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_resolve_skills_roots_skips_builtin_when_managed_dir_is_unwritable() {
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("remote-root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
+        let user_dir = home_dir.join(".config/agents/skills");
+        let project_dir = work_dir.join(".agents/skills");
+        std::fs::create_dir_all(&user_dir).expect("create user dir");
+        std::fs::create_dir_all(&project_dir).expect("create project dir");
+
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard =
+            FixedHomeKaosGuard::new("ssh", root_path, home_path, work_path.clone(), true);
+
+        let roots = resolve_skills_roots(&work_path, None).await;
+        assert_eq!(
+            roots,
+            vec![
+                KaosPath::unsafe_from_local_path(&user_dir),
+                KaosPath::unsafe_from_local_path(&project_dir),
+            ]
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_resolve_skills_roots_reuses_existing_read_only_builtin_bundle() {
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("remote-root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
+        std::fs::create_dir_all(&home_dir).expect("create home dir");
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+
+        let builtin_root = {
+            let _kaos_guard = FixedHomeKaosGuard::new(
+                "ssh",
+                root_path.clone(),
+                home_path.clone(),
+                work_path.clone(),
+                false,
+            );
+            let roots = resolve_skills_roots(&work_path, None).await;
+            assert!(!roots.is_empty());
+            roots[0].clone()
+        };
+
+        let ready_marker = builtin_root
+            .clone()
+            .unsafe_to_local_path()
+            .join(".bundle-ready");
+        std::fs::remove_file(&ready_marker).expect("remove ready marker");
+
+        let _kaos_guard = FixedHomeKaosGuard::new("ssh", root_path, home_path, work_path, true);
+        let roots = resolve_skills_roots(
+            &KaosPath::unsafe_from_local_path(&root_dir.join("work")),
+            None,
+        )
+        .await;
+        assert!(!roots.is_empty());
+        assert_eq!(roots[0], builtin_root);
+
+        let skills = discover_skills_from_roots(&roots).await;
+        let names: Vec<_> = skills.iter().map(|skill| skill.name.as_str()).collect();
+        assert!(names.contains(&"kimi-cli-help"));
+        assert!(names.contains(&"skill-creator"));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_override_bypasses_builtin_sync_when_managed_dir_is_unwritable() {
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("remote-root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
+        let override_dir = root_dir.join("override");
+        std::fs::create_dir_all(&home_dir).expect("create home dir");
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+        std::fs::create_dir_all(&override_dir).expect("create override dir");
+
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard = FixedHomeKaosGuard::new("ssh", root_path, home_path, work_path, true);
+
+        let roots = resolve_skills_roots(
+            &KaosPath::unsafe_from_local_path(&root_dir),
+            Some(KaosPath::unsafe_from_local_path(&override_dir)),
+        )
+        .await;
+        assert_eq!(roots, vec![KaosPath::unsafe_from_local_path(&override_dir)]);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn test_runtime_create_continues_without_builtin_skills_when_managed_dir_is_unwritable() {
+    with_current_kaos_scope(async {
+        let tmp = TempDir::new().expect("temp dir");
+        let root_dir = tmp.path().join("remote-root");
+        let home_dir = root_dir.join("home");
+        let work_dir = root_dir.join("work");
+        let share_dir = tmp.path().join("share");
+        std::fs::create_dir_all(&home_dir).expect("create home dir");
+        std::fs::create_dir_all(&work_dir).expect("create work dir");
+        std::fs::create_dir_all(&share_dir).expect("create share dir");
+
+        let root_path = KaosPath::unsafe_from_local_path(&root_dir);
+        let home_path = KaosPath::unsafe_from_local_path(&home_dir);
+        let work_path = KaosPath::unsafe_from_local_path(&work_dir);
+        let _kaos_guard =
+            FixedHomeKaosGuard::new("ssh", root_path, home_path, work_path.clone(), true);
+
+        let session = build_test_session(&work_path, &share_dir);
+        let runtime = Runtime::create(get_default_config(), None, session, true, None).await;
+        assert_eq!(runtime.builtin_args.KIMI_SKILLS, "No skills found.");
     })
     .await;
 }


### PR DESCRIPTION
## Summary
- embed builtin skills at build time and materialize them into the active Kaos managed state directory
- make builtin skill discovery best-effort, with `--skills-dir` acting as an exact-root override
- align local managed state with `KIMI_SHARE_DIR` and reuse existing builtin bundles when possible

## Validation
- cargo fmt
- cargo test -p kaos
- cargo test -p kimi-agent
- cargo clippy --workspace --all-targets -- -D warnings

Closes #10